### PR TITLE
Forward-port SGF parsing code for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pandas pytest h5py flask nose
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pandas pytest h5py flask nose six
   - source activate test-environment
   - pip install requests
   - pip install git+git://github.com/Theano/Theano.git

--- a/betago/dataloader/base_processor.py
+++ b/betago/dataloader/base_processor.py
@@ -11,12 +11,12 @@ import numpy as np
 import argparse
 import multiprocessing
 from os import sys
-from gomill import sgf as gosgf
 from keras.utils import np_utils
 
+from .. import gosgf
+from .goboard import GoBoard
 from .index_processor import KGSIndex
 from .sampling import Sampler
-from .goboard import GoBoard
 
 
 def worker(jobinfo):

--- a/betago/dataloader/goboard.py
+++ b/betago/dataloader/goboard.py
@@ -131,7 +131,7 @@ class GoBoard(object):
             return
         enemy_string = self.go_strings[enemy_pos]
         if enemy_string is None:
-            raise('check_string is None')
+            raise ValueError('Inconsistency between board and go_strings at %r' % enemy_pos)
 
         # Update adjacent liberties on board
         enemy_string.remove_liberty(our_pos)
@@ -154,7 +154,7 @@ class GoBoard(object):
         pos: Current move as (row, col)
         '''
         if pos in self.board:
-            raise('>>> Error: move ' + str(pos) + 'is already on board.')
+            raise ValueError('Move ' + str(pos) + 'is already on board.')
 
         self.ko_last_move_num_captured = 0
         row, col = pos

--- a/betago/dataloader/index_processor.py
+++ b/betago/dataloader/index_processor.py
@@ -1,8 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
-from __future__ import print_function, unicode_literals
-from builtins import unicode
+from __future__ import print_function
 import os
 import sys
 import urllib

--- a/betago/gosgf/__init__.py
+++ b/betago/gosgf/__init__.py
@@ -1,0 +1,1 @@
+from .sgf import *

--- a/betago/gosgf/sgf.py
+++ b/betago/gosgf/sgf.py
@@ -767,7 +767,7 @@ class Sgf_game(object):
 
         """
         try:
-            handicap = self.root.get("HA")
+            handicap = self.root.get(b"HA")
         except KeyError:
             return None
         if handicap == 0:

--- a/betago/gosgf/sgf.py
+++ b/betago/gosgf/sgf.py
@@ -1,0 +1,813 @@
+"""Represent SGF games.
+
+This is intended for use with SGF FF[4]; see http://www.red-bean.com/sgf/
+
+Adapted from gomill by Matthew Woodcraft, https://github.com/mattheww/gomill
+"""
+
+import datetime
+
+from . import sgf_grammar
+from . import sgf_properties
+
+__all__ = [
+    'Node',
+    'Sgf_game',
+    'Tree_node',
+]
+
+
+class Node(object):
+    """An SGF node.
+
+    Instantiate with a raw property map (see sgf_grammar) and an
+    sgf_properties.Presenter.
+
+    A Node doesn't belong to a particular game (cf Tree_node below), but it
+    knows its board size (in order to interpret move values) and the encoding
+    to use for the raw property strings.
+
+    Changing the SZ property isn't allowed.
+
+    """
+    def __init__(self, property_map, presenter):
+        # Map identifier (PropIdent) -> nonempty list of raw values
+        self._property_map = property_map
+        self._presenter = presenter
+
+    def get_size(self):
+        """Return the board size used to interpret property values."""
+        return self._presenter.size
+
+    def get_encoding(self):
+        """Return the encoding used for raw property values.
+
+        Returns a string (a valid Python codec name, eg "UTF-8").
+
+        """
+        return self._presenter.encoding
+
+    def get_presenter(self):
+        """Return the node's sgf_properties.Presenter."""
+        return self._presenter
+
+    def has_property(self, identifier):
+        """Check whether the node has the specified property."""
+        return identifier in self._property_map
+
+    def properties(self):
+        """Find the properties defined for the node.
+
+        Returns a list of property identifiers, in unspecified order.
+
+        """
+        return self._property_map.keys()
+
+    def get_raw_list(self, identifier):
+        """Return the raw values of the specified property.
+
+        Returns a nonempty list of 8-bit strings, in the raw property encoding.
+
+        The strings contain the exact bytes that go between the square brackets
+        (without interpreting escapes or performing any whitespace conversion).
+
+        Raises KeyError if there was no property with the given identifier.
+
+        (If the property is an empty elist, this returns a list containing a
+        single empty string.)
+
+        """
+        return self._property_map[identifier]
+
+    def get_raw(self, identifier):
+        """Return a single raw value of the specified property.
+
+        Returns an 8-bit string, in the raw property encoding.
+
+        The string contains the exact bytes that go between the square brackets
+        (without interpreting escapes or performing any whitespace conversion).
+
+        Raises KeyError if there was no property with the given identifier.
+
+        If the property has multiple values, this returns the first (if the
+        value is an empty elist, this returns an empty string).
+
+        """
+        return self._property_map[identifier][0]
+
+    def get_raw_property_map(self):
+        """Return the raw values of all properties as a dict.
+
+        Returns a dict mapping property identifiers to lists of raw values
+        (see get_raw_list()).
+
+        Returns the same dict each time it's called.
+
+        Treat the returned dict as read-only.
+
+        """
+        return self._property_map
+
+
+    def _set_raw_list(self, identifier, values):
+        if identifier == "SZ" and values != [str(self._presenter.size)]:
+            raise ValueError("changing size is not permitted")
+        self._property_map[identifier] = values
+
+    def unset(self, identifier):
+        """Remove the specified property.
+
+        Raises KeyError if the property isn't currently present.
+
+        """
+        if identifier == "SZ" and self._presenter.size != 19:
+            raise ValueError("changing size is not permitted")
+        del self._property_map[identifier]
+
+
+    def set_raw_list(self, identifier, values):
+        """Set the raw values of the specified property.
+
+        identifier -- ascii string passing is_valid_property_identifier()
+        values     -- nonempty iterable of 8-bit strings in the raw property
+                      encoding
+
+        The values specify the exact bytes to appear between the square
+        brackets in the SGF file; you must perform any necessary escaping
+        first.
+
+        (To specify an empty elist, pass a list containing a single empty
+        string.)
+
+        """
+        if not sgf_grammar.is_valid_property_identifier(identifier):
+            raise ValueError("ill-formed property identifier")
+        values = list(values)
+        if not values:
+            raise ValueError("empty property list")
+        for value in values:
+            if not sgf_grammar.is_valid_property_value(value):
+                raise ValueError("ill-formed raw property value")
+        self._set_raw_list(identifier, values)
+
+    def set_raw(self, identifier, value):
+        """Set the specified property to a single raw value.
+
+        identifier -- ascii string passing is_valid_property_identifier()
+        value      -- 8-bit string in the raw property encoding
+
+        The value specifies the exact bytes to appear between the square
+        brackets in the SGF file; you must perform any necessary escaping
+        first.
+
+        """
+        if not sgf_grammar.is_valid_property_identifier(identifier):
+            raise ValueError("ill-formed property identifier")
+        if not sgf_grammar.is_valid_property_value(value):
+            raise ValueError("ill-formed raw property value")
+        self._set_raw_list(identifier, [value])
+
+
+    def get(self, identifier):
+        """Return the interpreted value of the specified property.
+
+        Returns the value as a suitable Python representation.
+
+        Raises KeyError if the node does not have a property with the given
+        identifier.
+
+        Raises ValueError if it cannot interpret the value.
+
+        See sgf_properties.Presenter.interpret() for details.
+
+        """
+        return self._presenter.interpret(
+            identifier, self._property_map[identifier])
+
+    def set(self, identifier, value):
+        """Set the value of the specified property.
+
+        identifier -- ascii string passing is_valid_property_identifier()
+        value      -- new property value (in its Python representation)
+
+        For properties with value type 'none', use value True.
+
+        Raises ValueError if it cannot represent the value.
+
+        See sgf_properties.Presenter.serialise() for details.
+
+        """
+        self._set_raw_list(
+            identifier, self._presenter.serialise(identifier, value))
+
+    def get_raw_move(self):
+        """Return the raw value of the move from a node.
+
+        Returns a pair (colour, raw value)
+
+        colour is 'b' or 'w'.
+
+        Returns None, None if the node contains no B or W property.
+
+        """
+        values = self._property_map.get("B")
+        if values is not None:
+            colour = "b"
+        else:
+            values = self._property_map.get("W")
+            if values is not None:
+                colour = "w"
+            else:
+                return None, None
+        return colour, values[0]
+
+    def get_move(self):
+        """Retrieve the move from a node.
+
+        Returns a pair (colour, move)
+
+        colour is 'b' or 'w'.
+
+        move is (row, col), or None for a pass.
+
+        Returns None, None if the node contains no B or W property.
+
+        """
+        colour, raw = self.get_raw_move()
+        if colour is None:
+            return None, None
+        return (colour,
+                sgf_properties.interpret_go_point(raw, self._presenter.size))
+
+    def get_setup_stones(self):
+        """Retrieve Add Black / Add White / Add Empty properties from a node.
+
+        Returns a tuple (black_points, white_points, empty_points)
+
+        Each value is a set of pairs (row, col).
+
+        """
+        try:
+            bp = self.get("AB")
+        except KeyError:
+            bp = set()
+        try:
+            wp = self.get("AW")
+        except KeyError:
+            wp = set()
+        try:
+            ep = self.get("AE")
+        except KeyError:
+            ep = set()
+        return bp, wp, ep
+
+    def has_setup_stones(self):
+        """Check whether the node has any AB/AW/AE properties."""
+        d = self._property_map
+        return ("AB" in d or "AW" in d or "AE" in d)
+
+    def set_move(self, colour, move):
+        """Set the B or W property.
+
+        colour -- 'b' or 'w'.
+        move -- (row, col), or None for a pass.
+
+        Replaces any existing B or W property in the node.
+
+        """
+        if colour not in ('b', 'w'):
+            raise ValueError
+        if 'B' in self._property_map:
+            del self._property_map['B']
+        if 'W' in self._property_map:
+            del self._property_map['W']
+        self.set(colour.upper(), move)
+
+    def set_setup_stones(self, black, white, empty=None):
+        """Set Add Black / Add White / Add Empty properties.
+
+        black, white, empty -- list or set of pairs (row, col)
+
+        Removes any existing AB/AW/AE properties from the node.
+
+        """
+        if 'AB' in self._property_map:
+            del self._property_map['AB']
+        if 'AW' in self._property_map:
+            del self._property_map['AW']
+        if 'AE' in self._property_map:
+            del self._property_map['AE']
+        if black:
+            self.set('AB', black)
+        if white:
+            self.set('AW', white)
+        if empty:
+            self.set('AE', empty)
+
+    def add_comment_text(self, text):
+        """Add or extend the node's comment.
+
+        If the node doesn't have a C property, adds one with the specified
+        text.
+
+        Otherwise, adds the specified text to the existing C property value
+        (with two newlines in front).
+
+        """
+        if self.has_property('C'):
+            self.set('C', self.get('C') + "\n\n" + text)
+        else:
+            self.set('C', text)
+
+    def __str__(self):
+        def format_property(ident, values):
+            return ident + "".join("[%s]" % s for s in values)
+        return "\n".join(
+            format_property(ident, values)
+            for (ident, values) in sorted(self._property_map.items())) \
+            + "\n"
+
+
+class Tree_node(Node):
+    """A node embedded in an SGF game.
+
+    A Tree_node is a Node that also knows its position within an Sgf_game.
+
+    Do not instantiate directly; retrieve from an Sgf_game or another Tree_node.
+
+    A Tree_node is a list-like container of its children: it can be indexed,
+    sliced, and iterated over like a list, and supports index().
+
+    A Tree_node with no children is treated as having truth value false.
+
+    Public attributes (treat as read-only):
+      owner  -- the node's Sgf_game
+      parent -- the nodes's parent Tree_node (None for the root node)
+
+    """
+    def __init__(self, parent, properties):
+        self.owner = parent.owner
+        self.parent = parent
+        self._children = []
+        Node.__init__(self, properties, parent._presenter)
+
+    def _add_child(self, node):
+        self._children.append(node)
+
+    def __len__(self):
+        return len(self._children)
+
+    def __getitem__(self, key):
+        return self._children[key]
+
+    def index(self, child):
+        return self._children.index(child)
+
+    def new_child(self, index=None):
+        """Create a new Tree_node and add it as this node's last child.
+
+        If 'index' is specified, the new node is inserted in the child list at
+        the specified index instead (behaves like list.insert).
+
+        Returns the new node.
+
+        """
+        child = Tree_node(self, {})
+        if index is None:
+            self._children.append(child)
+        else:
+            self._children.insert(index, child)
+        return child
+
+    def delete(self):
+        """Remove this node from its parent."""
+        if self.parent is None:
+            raise ValueError("can't remove the root node")
+        self.parent._children.remove(self)
+
+    def reparent(self, new_parent, index=None):
+        """Move this node to a new place in the tree.
+
+        new_parent -- Tree_node from the same game.
+
+        Raises ValueError if the new parent is this node or one of its
+        descendants.
+
+        If 'index' is specified, the node is inserted in the new parent's child
+        list at the specified index (behaves like list.insert); otherwise it's
+        placed at the end.
+
+        """
+        if new_parent.owner != self.owner:
+            raise ValueError("new parent doesn't belong to the same game")
+        n = new_parent
+        while True:
+            if n == self:
+                raise ValueError("would create a loop")
+            n = n.parent
+            if n is None:
+                break
+        # self.parent is not None because moving the root would create a loop.
+        self.parent._children.remove(self)
+        self.parent = new_parent
+        if index is None:
+            new_parent._children.append(self)
+        else:
+            new_parent._children.insert(index, self)
+
+    def find(self, identifier):
+        """Find the nearest ancestor-or-self containing the specified property.
+
+        Returns a Tree_node, or None if there is no such node.
+
+        """
+        node = self
+        while node is not None:
+            if node.has_property(identifier):
+                return node
+            node = node.parent
+        return None
+
+    def find_property(self, identifier):
+        """Return the value of a property, defined at this node or an ancestor.
+
+        This is intended for use with properties of type 'game-info', and with
+        properties with the 'inherit' attribute.
+
+        This returns the interpreted value, in the same way as get().
+
+        It searches up the tree, in the same way as find().
+
+        Raises KeyError if no node defining the property is found.
+
+        """
+        node = self.find(identifier)
+        if node is None:
+            raise KeyError
+        return node.get(identifier)
+
+class _Root_tree_node(Tree_node):
+    """Variant of Tree_node used for a game root."""
+    def __init__(self, property_map, owner):
+        self.owner = owner
+        self.parent = None
+        self._children = []
+        Node.__init__(self, property_map, owner.presenter)
+
+class _Unexpanded_root_tree_node(_Root_tree_node):
+    """Variant of _Root_tree_node used with 'loaded' Sgf_games."""
+    def __init__(self, owner, coarse_tree):
+        _Root_tree_node.__init__(self, coarse_tree.sequence[0], owner)
+        self._coarse_tree = coarse_tree
+
+    def _expand(self):
+        sgf_grammar.make_tree(
+            self._coarse_tree, self, Tree_node, Tree_node._add_child)
+        delattr(self, '_coarse_tree')
+        self.__class__ = _Root_tree_node
+
+    def __len__(self):
+        self._expand()
+        return self.__len__()
+
+    def __getitem__(self, key):
+        self._expand()
+        return self.__getitem__(key)
+
+    def index(self, child):
+        self._expand()
+        return self.index(child)
+
+    def new_child(self, index=None):
+        self._expand()
+        return self.new_child(index)
+
+    def _main_sequence_iter(self):
+        presenter = self._presenter
+        for properties in sgf_grammar.main_sequence_iter(self._coarse_tree):
+            yield Node(properties, presenter)
+
+
+class Sgf_game(object):
+    """An SGF game tree.
+
+    The complete game tree is represented using Tree_nodes. The various methods
+    which return Tree_nodes will always return the same object for the same
+    node.
+
+    Instantiate with
+      size     -- int (board size), in range 1 to 26
+      encoding -- the raw property encoding (default "UTF-8")
+
+    'encoding' must be a valid Python codec name.
+
+    The following root node properties are set for newly-created games:
+      FF[4]
+      GM[1]
+      SZ[size]
+      CA[encoding]
+
+    Changing FF and GM is permitted (but this library will carry on using the
+    FF[4] and GM[1] rules). Changing SZ is not permitted (unless the change
+    leaves the effective value unchanged). Changing CA is permitted; this
+    controls the encoding used by serialise().
+
+    """
+    def __new__(cls, size, encoding="UTF-8", *args, **kwargs):
+        # To complete initialisation after this, you need to set 'root'.
+        if not 1 <= size <= 26:
+            raise ValueError("size out of range: %s" % size)
+        game = super(Sgf_game, cls).__new__(cls)
+        game.size = size
+        game.presenter = sgf_properties.Presenter(size, encoding)
+        return game
+
+    def __init__(self, *args, **kwargs):
+        self.root = _Root_tree_node({}, self)
+        self.root.set_raw('FF', "4")
+        self.root.set_raw('GM', "1")
+        self.root.set_raw('SZ', str(self.size))
+        # Read the encoding back so we get the normalised form
+        self.root.set_raw('CA', self.presenter.encoding)
+
+    @classmethod
+    def from_coarse_game_tree(cls, coarse_game, override_encoding=None):
+        """Alternative constructor: create an Sgf_game from the parser output.
+
+        coarse_game       -- Coarse_game_tree
+        override_encoding -- encoding name, eg "UTF-8" (optional)
+
+        The nodes' property maps (as returned by get_raw_property_map()) will
+        be the same dictionary objects as the ones from the Coarse_game_tree.
+
+        The board size and raw property encoding are taken from the SZ and CA
+        properties in the root node (defaulting to 19 and "ISO-8859-1",
+        respectively).
+
+        If override_encoding is specified, the source data is assumed to be in
+        the specified encoding (no matter what the CA property says), and the
+        CA property is set to match.
+
+        """
+        try:
+            size_s = coarse_game.sequence[0]['SZ'][0]
+        except KeyError:
+            size = 19
+        else:
+            try:
+                size = int(size_s)
+            except ValueError:
+                raise ValueError("bad SZ property: %s" % size_s)
+        if override_encoding is None:
+            try:
+                encoding = coarse_game.sequence[0]['CA'][0]
+            except KeyError:
+                encoding = "ISO-8859-1"
+        else:
+            encoding = override_encoding
+        game = cls.__new__(cls, size, encoding)
+        game.root = _Unexpanded_root_tree_node(game, coarse_game)
+        if override_encoding is not None:
+            game.root.set_raw("CA", game.presenter.encoding)
+        return game
+
+    @classmethod
+    def from_string(cls, s, override_encoding=None):
+        """Alternative constructor: read a single Sgf_game from a string.
+
+        s -- 8-bit string
+
+        Raises ValueError if it can't parse the string. See parse_sgf_game()
+        for details.
+
+        See from_coarse_game_tree for details of size and encoding handling.
+
+        """
+        coarse_game = sgf_grammar.parse_sgf_game(s)
+        return cls.from_coarse_game_tree(coarse_game, override_encoding)
+
+    def serialise(self, wrap=79):
+        """Serialise the SGF data as a string.
+
+        wrap -- int (default 79), or None
+
+        Returns an 8-bit string, in the encoding specified by the CA property
+        in the root node (defaulting to "ISO-8859-1").
+
+        If the raw property encoding and the target encoding match (which is
+        the usual case), the raw property values are included unchanged in the
+        output (even if they are improperly encoded.)
+
+        Otherwise, if any raw property value is improperly encoded,
+        UnicodeDecodeError is raised, and if any property value can't be
+        represented in the target encoding, UnicodeEncodeError is raised.
+
+        If the target encoding doesn't identify a Python codec, ValueError is
+        raised. Behaviour is unspecified if the target encoding isn't
+        ASCII-compatible (eg, UTF-16).
+
+        If 'wrap' is not None, makes some effort to keep output lines no longer
+        than 'wrap'.
+
+        """
+        try:
+            encoding = self.get_charset()
+        except ValueError:
+            raise ValueError("unsupported charset: %s" %
+                             self.root.get_raw_list("CA"))
+        coarse_tree = sgf_grammar.make_coarse_game_tree(
+            self.root, lambda node:node, Node.get_raw_property_map)
+        serialised = sgf_grammar.serialise_game_tree(coarse_tree, wrap)
+        if encoding == self.root.get_encoding():
+            return serialised
+        else:
+            return serialised.decode(self.root.get_encoding()).encode(encoding)
+
+
+    def get_property_presenter(self):
+        """Return the property presenter.
+
+        Returns an sgf_properties.Presenter.
+
+        This can be used to customise how property values are interpreted and
+        serialised.
+
+        """
+        return self.presenter
+
+    def get_root(self):
+        """Return the root node (as a Tree_node)."""
+        return self.root
+
+    def get_last_node(self):
+        """Return the last node in the 'leftmost' variation (as a Tree_node)."""
+        node = self.root
+        while node:
+            node = node[0]
+        return node
+
+    def get_main_sequence(self):
+        """Return the 'leftmost' variation.
+
+        Returns a list of Tree_nodes, from the root to a leaf.
+
+        """
+        node = self.root
+        result = [node]
+        while node:
+            node = node[0]
+            result.append(node)
+        return result
+
+    def get_main_sequence_below(self, node):
+        """Return the 'leftmost' variation below the specified node.
+
+        node -- Tree_node
+
+        Returns a list of Tree_nodes, from the first child of 'node' to a leaf.
+
+        """
+        if node.owner is not self:
+            raise ValueError("node doesn't belong to this game")
+        result = []
+        while node:
+            node = node[0]
+            result.append(node)
+        return result
+
+    def get_sequence_above(self, node):
+        """Return the partial variation leading to the specified node.
+
+        node -- Tree_node
+
+        Returns a list of Tree_nodes, from the root to the parent of 'node'.
+
+        """
+        if node.owner is not self:
+            raise ValueError("node doesn't belong to this game")
+        result = []
+        while node.parent is not None:
+            node = node.parent
+            result.append(node)
+        result.reverse()
+        return result
+
+    def main_sequence_iter(self):
+        """Provide the 'leftmost' variation as an iterator.
+
+        Returns an iterator providing Node instances, from the root to a leaf.
+
+        The Node instances may or may not be Tree_nodes.
+
+        It's OK to use these Node instances to modify properties: even if they
+        are not the same objects as returned by the main tree navigation
+        methods, they share the underlying property maps.
+
+        If you know the game has no variations, or you're only interested in
+        the 'leftmost' variation, you can use this function to retrieve the
+        nodes without building the entire game tree.
+
+        """
+        if isinstance(self.root, _Unexpanded_root_tree_node):
+            return self.root._main_sequence_iter()
+        return iter(self.get_main_sequence())
+
+    def extend_main_sequence(self):
+        """Create a new Tree_node and add to the 'leftmost' variation.
+
+        Returns the new node.
+
+        """
+        return self.get_last_node().new_child()
+
+    def get_size(self):
+        """Return the board size as an integer."""
+        return self.size
+
+    def get_charset(self):
+        """Return the effective value of the CA root property.
+
+        This applies the default, and returns the normalised form.
+
+        Raises ValueError if the CA property doesn't identify a Python codec.
+
+        """
+        try:
+            s = self.root.get("CA")
+        except KeyError:
+            return "ISO-8859-1"
+        try:
+            return sgf_properties.normalise_charset_name(s)
+        except LookupError:
+            raise ValueError("no codec available for CA %s" % s)
+
+    def get_komi(self):
+        """Return the komi as a float.
+
+        Returns 0.0 if the KM property isn't present in the root node.
+
+        Raises ValueError if the KM property is malformed.
+
+        """
+        try:
+            return self.root.get("KM")
+        except KeyError:
+            return 0.0
+
+    def get_handicap(self):
+        """Return the number of handicap stones as a small integer.
+
+        Returns None if the HA property isn't present, or has (illegal) value
+        zero.
+
+        Raises ValueError if the HA property is otherwise malformed.
+
+        """
+        try:
+            handicap = self.root.get("HA")
+        except KeyError:
+            return None
+        if handicap == 0:
+            handicap = None
+        elif handicap == 1:
+            raise ValueError
+        return handicap
+
+    def get_player_name(self, colour):
+        """Return the name of the specified player.
+
+        Returns None if there is no corresponding 'PB' or 'PW' property.
+
+        """
+        try:
+            return self.root.get({'b' : 'PB', 'w' : 'PW'}[colour])
+        except KeyError:
+            return None
+
+    def get_winner(self):
+        """Return the colour of the winning player.
+
+        Returns None if there is no RE property, or if neither player won.
+
+        """
+        try:
+            colour = self.root.get("RE")[0].lower()
+        except LookupError:
+            return None
+        if colour not in ("b", "w"):
+            return None
+        return colour
+
+    def set_date(self, date=None):
+        """Set the DT property to a single date.
+
+        date -- datetime.date (defaults to today)
+
+        (SGF allows dates to be rather more complicated than this, so there's
+         no corresponding get_date() method.)
+
+        """
+        if date is None:
+            date = datetime.date.today()
+        self.root.set('DT', date.strftime("%Y-%m-%d"))
+

--- a/betago/gosgf/sgf_grammar.py
+++ b/betago/gosgf/sgf_grammar.py
@@ -311,7 +311,7 @@ def serialise_game_tree(game_tree, wrap=79):
                 # block_format output.
                 m = [prop_ident]
                 for value in prop_values:
-                    m.append(b"[%s]" % value)
+                    m.append(b"[" + value + b"]")
                 l.append(b"".join(m))
         to_serialise.append(None)
         to_serialise.extend(reversed(game_tree.children))

--- a/betago/gosgf/sgf_grammar.py
+++ b/betago/gosgf/sgf_grammar.py
@@ -23,6 +23,8 @@ Adapted from gomill by Matthew Woodcraft, https://github.com/mattheww/gomill
 import re
 import string
 
+import six
+
 
 _propident_re = re.compile(r"\A[A-Z]{1,8}\Z".encode('ascii'))
 _propvalue_re = re.compile(r"\A [^\\\]]* (?: \\. [^\\\]]* )* \Z".encode('ascii'),
@@ -436,7 +438,11 @@ def compose(s1, s2):
 
 
 _newline_re = re.compile(r"\n\r|\r\n|\n|\r".encode('ascii'))
-_whitespace_table = bytes.maketrans(b"\t\f\v", b"   ")
+if six.PY2:
+    _binary_maketrans = string.maketrans
+else:
+    _binary_maketrans = bytes.maketrans
+_whitespace_table = _binary_maketrans(b"\t\f\v", b"   ")
 _chunk_re = re.compile(r" [^\n\\]+ | [\n\\] ".encode('ascii'), re.VERBOSE)
 
 def simpletext_value(s):

--- a/betago/gosgf/sgf_grammar.py
+++ b/betago/gosgf/sgf_grammar.py
@@ -1,0 +1,514 @@
+"""Parse and serialise SGF data.
+
+This is intended for use with SGF FF[4]; see http://www.red-bean.com/sgf/
+
+Nothing in this module is Go-specific.
+
+This module is encoding-agnostic: it works with 8-bit strings in an arbitrary
+'ascii-compatible' encoding.
+
+
+In the documentation below, a _property map_ is a dict mapping a PropIdent to a
+nonempty list of raw property values.
+
+A raw property value is an 8-bit string containing a PropValue without its
+enclosing brackets, but with backslashes and line endings left untouched.
+
+So a property map's keys should pass is_valid_property_identifier(), and its
+values should pass is_valid_property_value().
+
+Adapted from gomill by Matthew Woodcraft, https://github.com/mattheww/gomill
+"""
+
+import re
+import string
+
+
+_propident_re = re.compile(r"\A[A-Z]{1,8}\Z")
+_propvalue_re = re.compile(r"\A [^\\\]]* (?: \\. [^\\\]]* )* \Z",
+                           re.VERBOSE | re.DOTALL)
+_find_start_re = re.compile(r"\(\s*;")
+_tokenise_re = re.compile(r"""
+\s*
+(?:
+    \[ (?P<V> [^\\\]]* (?: \\. [^\\\]]* )* ) \]   # PropValue
+    |
+    (?P<I> [A-Z]{1,8} )                           # PropIdent
+    |
+    (?P<D> [;()] )                                # delimiter
+)
+""", re.VERBOSE | re.DOTALL)
+
+
+def is_valid_property_identifier(s):
+    """Check whether 's' is a well-formed PropIdent.
+
+    s -- 8-bit string
+
+    This accepts the same values as the tokeniser.
+
+    Details:
+     - it doesn't permit lower-case letters (these are allowed in some ancient
+       SGF variants)
+     - it accepts at most 8 letters (there is no limit in the spec; no standard
+       property has more than 2)
+
+    """
+    return bool(_propident_re.search(s))
+
+def is_valid_property_value(s):
+    """Check whether 's' is a well-formed PropValue.
+
+    s -- 8-bit string
+
+    This accepts the same values as the tokeniser: any string that doesn't
+    contain an unescaped ] or end with an unescaped \ .
+
+    """
+    return bool(_propvalue_re.search(s))
+
+def tokenise(s, start_position=0):
+    """Tokenise a string containing SGF data.
+
+    s              -- 8-bit string
+    start_position -- index into 's'
+
+    Skips leading junk.
+
+    Returns a list of pairs of strings (token type, contents), and also the
+    index in 's' of the start of the unprocessed 'tail'.
+
+    token types and contents:
+      I -- PropIdent: upper-case letters
+      V -- PropValue: raw value, without the enclosing brackets
+      D -- delimiter: ';', '(', or ')'
+
+    Stops when it has seen as many closing parens as open ones, at the end of
+    the string, or when it first finds something it can't tokenise.
+
+    The first two tokens are always '(' and ';' (otherwise it won't find the
+    start of the content).
+
+    """
+    result = []
+    m = _find_start_re.search(s, start_position)
+    if not m:
+        return [], 0
+    i = m.start()
+    depth = 0
+    while True:
+        m = _tokenise_re.match(s, i)
+        if not m:
+            break
+        group = m.lastgroup
+        token = m.group(m.lastindex)
+        result.append((group, token))
+        i = m.end()
+        if group == 'D':
+            if token == '(':
+                depth += 1
+            elif token == ')':
+                depth -= 1
+                if depth == 0:
+                    break
+    return result, i
+
+class Coarse_game_tree(object):
+    """An SGF GameTree.
+
+    This is a direct representation of the SGF parse tree. It's 'coarse' in the
+    sense that the objects in the tree structure represent node sequences, not
+    individual nodes.
+
+    Public attributes
+      sequence -- nonempty list of property maps
+      children -- list of Coarse_game_trees
+
+    The sequence represents the nodes before the variations.
+
+    """
+    def __init__(self):
+        self.sequence = [] # must be at least one node
+        self.children = [] # may be empty
+
+def _parse_sgf_game(s, start_position):
+    """Common implementation for parse_sgf_game and parse_sgf_games."""
+    tokens, end_position = tokenise(s, start_position)
+    if not tokens:
+        return None, None
+    stack = []
+    game_tree = None
+    sequence = None
+    properties = None
+    index = 0
+    try:
+        while True:
+            token_type, token = tokens[index]
+            index += 1
+            if token_type == 'V':
+                raise ValueError("unexpected value")
+            if token_type == 'D':
+                if token == ';':
+                    if sequence is None:
+                        raise ValueError("unexpected node")
+                    properties = {}
+                    sequence.append(properties)
+                else:
+                    if sequence is not None:
+                        if not sequence:
+                            raise ValueError("empty sequence")
+                        game_tree.sequence = sequence
+                        sequence = None
+                    if token == '(':
+                        stack.append(game_tree)
+                        game_tree = Coarse_game_tree()
+                        sequence = []
+                    else:
+                        # token == ')'
+                        variation = game_tree
+                        game_tree = stack.pop()
+                        if game_tree is None:
+                            break
+                        game_tree.children.append(variation)
+                    properties = None
+            else:
+                # token_type == 'I'
+                prop_ident = token
+                prop_values = []
+                while True:
+                    token_type, token = tokens[index]
+                    if token_type != 'V':
+                        break
+                    index += 1
+                    prop_values.append(token)
+                if not prop_values:
+                    raise ValueError("property with no values")
+                try:
+                    if prop_ident in properties:
+                        properties[prop_ident] += prop_values
+                    else:
+                        properties[prop_ident] = prop_values
+                except TypeError:
+                    raise ValueError("property value outside a node")
+    except IndexError:
+        raise ValueError("unexpected end of SGF data")
+    assert index == len(tokens)
+    return variation, end_position
+
+def parse_sgf_game(s):
+    """Read a single SGF game from a string, returning the parse tree.
+
+    s -- 8-bit string
+
+    Returns a Coarse_game_tree.
+
+    Applies the rules for FF[4].
+
+    Raises ValueError if can't parse the string.
+
+    If a property appears more than once in a node (which is not permitted by
+    the spec), treats it the same as a single property with multiple values.
+
+
+    Identifies the start of the SGF content by looking for '(;' (with possible
+    whitespace between); ignores everything preceding that. Ignores everything
+    following the first game.
+
+    """
+    game_tree, _ = _parse_sgf_game(s, 0)
+    if game_tree is None:
+        raise ValueError("no SGF data found")
+    return game_tree
+
+def parse_sgf_collection(s):
+    """Read an SGF game collection, returning the parse trees.
+
+    s -- 8-bit string
+
+    Returns a nonempty list of Coarse_game_trees.
+
+    Raises ValueError if no games were found in the string.
+
+    Raises ValueError if there is an error parsing a game. See
+    parse_sgf_game() for details.
+
+
+    Ignores non-SGF data before the first game, between games, and after the
+    final game. Identifies the start of each game in the same way as
+    parse_sgf_game().
+
+    """
+    position = 0
+    result = []
+    while True:
+        try:
+            game_tree, position = _parse_sgf_game(s, position)
+        except ValueError, e:
+            raise ValueError("error parsing game %d: %s" % (len(result), e))
+        if game_tree is None:
+            break
+        result.append(game_tree)
+    if not result:
+        raise ValueError("no SGF data found")
+    return result
+
+
+def block_format(pieces, width=79):
+    """Concatenate strings, adding newlines.
+
+    pieces -- iterable of strings
+    width  -- int (default 79)
+
+    Returns "".join(pieces), with added newlines between pieces as necessary to
+    avoid lines longer than 'width'.
+
+    Leaves newlines inside 'pieces' untouched, and ignores them in its width
+    calculation. If a single piece is longer than 'width', it will become a
+    single long line in the output.
+
+    """
+    lines = []
+    line = ""
+    for s in pieces:
+        if len(line) + len(s) > width:
+            lines.append(line)
+            line = ""
+        line += s
+    if line:
+        lines.append(line)
+    return "\n".join(lines)
+
+def serialise_game_tree(game_tree, wrap=79):
+    """Serialise an SGF game as a string.
+
+    game_tree -- Coarse_game_tree
+    wrap      -- int (default 79), or None
+
+    Returns an 8-bit string, ending with a newline.
+
+    If 'wrap' is not None, makes some effort to keep output lines no longer
+    than 'wrap'.
+
+    """
+    l = []
+    to_serialise = [game_tree]
+    while to_serialise:
+        game_tree = to_serialise.pop()
+        if game_tree is None:
+            l.append(")")
+            continue
+        l.append("(")
+        for properties in game_tree.sequence:
+            l.append(";")
+            # Force FF to the front, largely to work around a Quarry bug which
+            # makes it ignore the first few bytes of the file.
+            for prop_ident, prop_values in sorted(
+                    properties.iteritems(),
+                    key=lambda (ident, _,): (-(ident=="FF"), ident)):
+                # Make a single string for each property, to get prettier
+                # block_format output.
+                m = [prop_ident]
+                for value in prop_values:
+                    m.append("[%s]" % value)
+                l.append("".join(m))
+        to_serialise.append(None)
+        to_serialise.extend(reversed(game_tree.children))
+    l.append("\n")
+    if wrap is None:
+        return "".join(l)
+    else:
+        return block_format(l, wrap)
+
+
+def make_tree(game_tree, root, node_builder, node_adder):
+    """Construct a node tree from a Coarse_game_tree.
+
+    game_tree    -- Coarse_game_tree
+    root         -- node
+    node_builder -- function taking parameters (parent node, property map)
+                    returning a node
+    node_adder   -- function taking a pair (parent node, child node)
+
+    Builds a tree of nodes corresponding to this GameTree, calling
+    node_builder() to make new nodes and node_adder() to add child nodes to
+    their parent.
+
+    Makes no further assumptions about the node type.
+
+    """
+    to_build = [(root, game_tree, 0)]
+    while to_build:
+        node, game_tree, index = to_build.pop()
+        if index < len(game_tree.sequence) - 1:
+            child = node_builder(node, game_tree.sequence[index+1])
+            node_adder(node, child)
+            to_build.append((child, game_tree, index+1))
+        else:
+            node._children = []
+            for child_tree in game_tree.children:
+                child = node_builder(node, child_tree.sequence[0])
+                node_adder(node, child)
+                to_build.append((child, child_tree, 0))
+
+def make_coarse_game_tree(root, get_children, get_properties):
+    """Construct a Coarse_game_tree from a node tree.
+
+    root           -- node
+    get_children   -- function taking a node, returning a sequence of nodes
+    get_properties -- function taking a node, returning a property map
+
+    Returns a Coarse_game_tree.
+
+    Walks the node tree based at 'root' using get_children(), and uses
+    get_properties() to extract the raw properties.
+
+    Makes no further assumptions about the node type.
+
+    Doesn't check that the property maps have well-formed keys and values.
+
+    """
+    result = Coarse_game_tree()
+    to_serialise = [(result, root)]
+    while to_serialise:
+        game_tree, node = to_serialise.pop()
+        while True:
+            game_tree.sequence.append(get_properties(node))
+            children = get_children(node)
+            if len(children) != 1:
+                break
+            node = children[0]
+        for child in children:
+            child_tree = Coarse_game_tree()
+            game_tree.children.append(child_tree)
+            to_serialise.append((child_tree, child))
+    return result
+
+
+def main_sequence_iter(game_tree):
+    """Provide the 'leftmost' complete sequence of a Coarse_game_tree.
+
+    game_tree -- Coarse_game_tree
+
+    Returns an iterable of property maps.
+
+    If the game has no variations, this provides the complete game. Otherwise,
+    it chooses the first variation each time it has a choice.
+
+    """
+    while True:
+        for properties in game_tree.sequence:
+            yield properties
+        if not game_tree.children:
+            break
+        game_tree = game_tree.children[0]
+
+
+_split_compose_re = re.compile(
+    r"( (?: [^\\:] | \\. )* ) :",
+    re.VERBOSE | re.DOTALL)
+
+def parse_compose(s):
+    """Split the parts of an SGF Compose value.
+
+    If the value is a well-formed Compose, returns a pair of strings.
+
+    If it isn't (ie, there is no delimiter), returns the complete string and
+    None.
+
+    Interprets backslash escapes in order to find the delimiter, but leaves
+    backslash escapes unchanged in the returned strings.
+
+    """
+    m = _split_compose_re.match(s)
+    if not m:
+        return s, None
+    return m.group(1), s[m.end():]
+
+def compose(s1, s2):
+    """Construct a value of Compose value type.
+
+    s1, s2 -- serialised form of a property value
+
+    (This is only needed if the type of the first value permits colons.)
+
+    """
+    return s1.replace(":", "\\:") + ":" + s2
+
+
+_newline_re = re.compile(r"\n\r|\r\n|\n|\r")
+_whitespace_table = string.maketrans("\t\f\v", "   ")
+_chunk_re = re.compile(r" [^\n\\]+ | [\n\\] ", re.VERBOSE)
+
+def simpletext_value(s):
+    """Convert a raw SimpleText property value to the string it represents.
+
+    Returns an 8-bit string, in the encoding of the original SGF string.
+
+    This interprets escape characters, and does whitespace mapping:
+
+    - backslash followed by linebreak (LF, CR, LFCR, or CRLF) disappears
+    - any other linebreak is replaced by a space
+    - any other whitespace character is replaced by a space
+    - other backslashes disappear (but double-backslash -> single-backslash)
+
+    """
+    s = _newline_re.sub("\n", s)
+    s = s.translate(_whitespace_table)
+    is_escaped = False
+    result = []
+    for chunk in _chunk_re.findall(s):
+        if is_escaped:
+            if chunk != "\n":
+                result.append(chunk)
+            is_escaped = False
+        elif chunk == "\\":
+            is_escaped = True
+        elif chunk == "\n":
+            result.append(" ")
+        else:
+            result.append(chunk)
+    return "".join(result)
+
+def text_value(s):
+    """Convert a raw Text property value to the string it represents.
+
+    Returns an 8-bit string, in the encoding of the original SGF string.
+
+    This interprets escape characters, and does whitespace mapping:
+
+    - linebreak (LF, CR, LFCR, or CRLF) is converted to \n
+    - any other whitespace character is replaced by a space
+    - backslash followed by linebreak disappears
+    - other backslashes disappear (but double-backslash -> single-backslash)
+
+    """
+    s = _newline_re.sub("\n", s)
+    s = s.translate(_whitespace_table)
+    is_escaped = False
+    result = []
+    for chunk in _chunk_re.findall(s):
+        if is_escaped:
+            if chunk != "\n":
+                result.append(chunk)
+            is_escaped = False
+        elif chunk == "\\":
+            is_escaped = True
+        else:
+            result.append(chunk)
+    return "".join(result)
+
+def escape_text(s):
+    """Convert a string to a raw Text property value that represents it.
+
+    s -- 8-bit string, in the desired output encoding.
+
+    Returns an 8-bit string which passes is_valid_property_value().
+
+    Normally text_value(escape_text(s)) == s, but there are the following
+    exceptions:
+     - all linebreaks are are normalised to \n
+     - whitespace other than line breaks is converted to a single space
+
+    """
+    return s.replace("\\", "\\\\").replace("]", "\\]")
+

--- a/betago/gosgf/sgf_properties.py
+++ b/betago/gosgf/sgf_properties.py
@@ -1,0 +1,731 @@
+"""Interpret SGF property values.
+
+This is intended for use with SGF FF[4]; see http://www.red-bean.com/sgf/
+
+This supports all general properties and Go-specific properties, but not
+properties for other games. Point, Move and Stone values are interpreted as Go
+points.
+
+Adapted from gomill by Matthew Woodcraft, https://github.com/mattheww/gomill
+"""
+
+import codecs
+from math import isinf, isnan
+
+from . import sgf_grammar
+
+def normalise_charset_name(s):
+    """Convert an encoding name to the form implied in the SGF spec.
+
+    In particular, normalises to 'ISO-8859-1' and 'UTF-8'.
+
+    Raises LookupError if the encoding name isn't known to Python.
+
+    """
+    return (codecs.lookup(s).name.replace("_", "-").upper()
+            .replace("ISO8859", "ISO-8859"))
+
+
+def interpret_go_point(s, size):
+    """Convert a raw SGF Go Point, Move, or Stone value to coordinates.
+
+    s    -- 8-bit string
+    size -- board size (int)
+
+    Returns a pair (row, col), or None for a pass.
+
+    Raises ValueError if the string is malformed or the coordinates are out of
+    range.
+
+    Only supports board sizes up to 26.
+
+    The returned coordinates are in the GTP coordinate system (as in the rest
+    of gomill), where (0, 0) is the lower left.
+
+    """
+    if s == "" or (s == "tt" and size <= 19):
+        return None
+    # May propagate ValueError
+    col_s, row_s = s
+    col = ord(col_s) - 97 # 97 == ord("a")
+    row = size - ord(row_s) + 96
+    if not ((0 <= col < size) and (0 <= row < size)):
+        raise ValueError
+    return row, col
+
+def serialise_go_point(move, size):
+    """Serialise a Go Point, Move, or Stone value.
+
+    move -- pair (row, col), or None for a pass
+
+    Returns an 8-bit string.
+
+    Only supports board sizes up to 26.
+
+    The move coordinates are in the GTP coordinate system (as in the rest of
+    gomill), where (0, 0) is the lower left.
+
+    """
+    if not 1 <= size <= 26:
+        raise ValueError
+    if move is None:
+        # Prefer 'tt' where possible, for the sake of older code
+        if size <= 19:
+            return "tt"
+        else:
+            return ""
+    row, col = move
+    if not ((0 <= col < size) and (0 <= row < size)):
+        raise ValueError
+    col_s = "abcdefghijklmnopqrstuvwxy"[col]
+    row_s = "abcdefghijklmnopqrstuvwxy"[size - row - 1]
+    return col_s + row_s
+
+
+class _Context(object):
+    def __init__(self, size, encoding):
+        self.size = size
+        self.encoding = encoding
+
+def interpret_none(s, context=None):
+    """Convert a raw None value to a boolean.
+
+    That is, unconditionally returns True.
+
+    """
+    return True
+
+def serialise_none(b, context=None):
+    """Serialise a None value.
+
+    Ignores its parameter.
+
+    """
+    return ""
+
+
+def interpret_number(s, context=None):
+    """Convert a raw Number value to the integer it represents.
+
+    This is a little more lenient than the SGF spec: it permits leading and
+    trailing spaces, and spaces between the sign and the numerals.
+
+    """
+    return int(s, 10)
+
+def serialise_number(i, context=None):
+    """Serialise a Number value.
+
+    i -- integer
+
+    """
+    return "%d" % i
+
+
+def interpret_real(s, context=None):
+    """Convert a raw Real value to the float it represents.
+
+    This is more lenient than the SGF spec: it accepts strings accepted as a
+    float by the platform libc. It rejects infinities and NaNs.
+
+    """
+    result = float(s)
+    if isinf(result):
+        raise ValueError("infinite")
+    if isnan(result):
+        raise ValueError("not a number")
+    return result
+
+def serialise_real(f, context=None):
+    """Serialise a Real value.
+
+    f -- real number (int or float)
+
+    If the absolute value is too small to conveniently express as a decimal,
+    returns "0" (this currently happens if abs(f) is less than 0.0001).
+
+    """
+    f = float(f)
+    try:
+        i = int(f)
+    except OverflowError:
+        # infinity
+        raise ValueError
+    if f == i:
+        # avoid trailing '.0'; also avoid scientific notation for large numbers
+        return str(i)
+    s = repr(f)
+    if 'e-' in s:
+        return "0"
+    return s
+
+
+def interpret_double(s, context=None):
+    """Convert a raw Double value to an integer.
+
+    Returns 1 or 2 (unknown values are treated as 1).
+
+    """
+    if s.strip() == "2":
+        return 2
+    else:
+        return 1
+
+def serialise_double(i, context=None):
+    """Serialise a Double value.
+
+    i -- integer (1 or 2)
+
+    (unknown values are treated as 1)
+
+    """
+    if i == 2:
+        return "2"
+    return "1"
+
+
+def interpret_colour(s, context=None):
+    """Convert a raw Color value to a gomill colour.
+
+    Returns 'b' or 'w'.
+
+    """
+    colour = s.lower()
+    if colour not in ('b', 'w'):
+        raise ValueError
+    return colour
+
+def serialise_colour(colour, context=None):
+    """Serialise a Colour value.
+
+    colour -- 'b' or 'w'
+
+    """
+    if colour not in ('b', 'w'):
+        raise ValueError
+    return colour.upper()
+
+
+def _transcode(s, encoding):
+    """Common implementation for interpret_text and interpret_simpletext."""
+    # If encoding is UTF-8, we don't need to transcode, but we still want to
+    # report an error if it's not properly encoded.
+    u = s.decode(encoding)
+    if encoding == "UTF-8":
+        return s
+    else:
+        return u.encode("utf-8")
+
+def interpret_simpletext(s, context):
+    """Convert a raw SimpleText value to a string.
+
+    See sgf_grammar.simpletext_value() for details.
+
+    s -- raw value
+
+    Returns an 8-bit utf-8 string.
+
+    """
+    return _transcode(sgf_grammar.simpletext_value(s), context.encoding)
+
+def serialise_simpletext(s, context):
+    """Serialise a SimpleText value.
+
+    See sgf_grammar.escape_text() for details.
+
+    s -- 8-bit utf-8 string
+
+    """
+    if context.encoding != "UTF-8":
+        s = s.decode("utf-8").encode(context.encoding)
+    return sgf_grammar.escape_text(s)
+
+
+def interpret_text(s, context):
+    """Convert a raw Text value to a string.
+
+    See sgf_grammar.text_value() for details.
+
+    s -- raw value
+
+    Returns an 8-bit utf-8 string.
+
+    """
+    return _transcode(sgf_grammar.text_value(s), context.encoding)
+
+def serialise_text(s, context):
+    """Serialise a Text value.
+
+    See sgf_grammar.escape_text() for details.
+
+    s -- 8-bit utf-8 string
+
+    """
+    if context.encoding != "UTF-8":
+        s = s.decode("utf-8").encode(context.encoding)
+    return sgf_grammar.escape_text(s)
+
+
+
+def interpret_point(s, context):
+    """Convert a raw SGF Point or Stone value to coordinates.
+
+    See interpret_go_point() above for details.
+
+    Returns a pair (row, col).
+
+    """
+    result = interpret_go_point(s, context.size)
+    if result is None:
+        raise ValueError
+    return result
+
+def serialise_point(point, context):
+    """Serialise a Point or Stone value.
+
+    point -- pair (row, col)
+
+    See serialise_go_point() above for details.
+
+    """
+    if point is None:
+        raise ValueError
+    return serialise_go_point(point, context.size)
+
+
+def interpret_move(s, context):
+    """Convert a raw SGF Move value to coordinates.
+
+    See interpret_go_point() above for details.
+
+    Returns a pair (row, col), or None for a pass.
+
+    """
+    return interpret_go_point(s, context.size)
+
+def serialise_move(move, context):
+    """Serialise a Move value.
+
+    move -- pair (row, col), or None for a pass
+
+    See serialise_go_point() above for details.
+
+    """
+    return serialise_go_point(move, context.size)
+
+
+def interpret_point_list(values, context):
+    """Convert a raw SGF list of Points to a set of coordinates.
+
+    values -- list of strings
+
+    Returns a set of pairs (row, col).
+
+    If 'values' is empty, returns an empty set.
+
+    This interprets compressed point lists.
+
+    Doesn't complain if there is overlap, or if a single point is specified as
+    a 1x1 rectangle.
+
+    Raises ValueError if the data is otherwise malformed.
+
+    """
+    result = set()
+    for s in values:
+        # No need to use parse_compose(), as \: would always be an error.
+        p1, is_rectangle, p2 = s.partition(":")
+        if is_rectangle:
+            top, left = interpret_point(p1, context)
+            bottom, right = interpret_point(p2, context)
+            if not (bottom <= top and left <= right):
+                raise ValueError
+            for row in xrange(bottom, top+1):
+                for col in xrange(left, right+1):
+                    result.add((row, col))
+        else:
+            pt = interpret_point(p1, context)
+            result.add(pt)
+    return result
+
+def serialise_point_list(points, context):
+    """Serialise a list of Points, Moves, or Stones.
+
+    points -- iterable of pairs (row, col)
+
+    Returns a list of strings.
+
+    If 'points' is empty, returns an empty list.
+
+    Doesn't produce a compressed point list.
+
+    """
+    result = [serialise_point(point, context) for point in points]
+    result.sort()
+    return result
+
+
+def interpret_AP(s, context):
+    """Interpret an AP (application) property value.
+
+    Returns a pair of strings (name, version number)
+
+    Permits the version number to be missing (which is forbidden by the SGF
+    spec), in which case the second returned value is an empty string.
+
+    """
+    application, version = sgf_grammar.parse_compose(s)
+    if version is None:
+        version = ""
+    return (interpret_simpletext(application, context),
+            interpret_simpletext(version, context))
+
+def serialise_AP(value, context):
+    """Serialise an AP (application) property value.
+
+    value -- pair (application, version)
+      application -- string
+      version     -- string
+
+    Note this takes a single parameter (which is a pair).
+
+    """
+    application, version = value
+    return sgf_grammar.compose(serialise_simpletext(application, context),
+                               serialise_simpletext(version, context))
+
+
+def interpret_ARLN_list(values, context):
+    """Interpret an AR (arrow) or LN (line) property value.
+
+    Returns a list of pairs (point, point), where point is a pair (row, col)
+
+    """
+    result = []
+    for s in values:
+        p1, p2 = sgf_grammar.parse_compose(s)
+        result.append((interpret_point(p1, context),
+                       interpret_point(p2, context)))
+    return result
+
+def serialise_ARLN_list(values, context):
+    """Serialise an AR (arrow) or LN (line) property value.
+
+    values -- list of pairs (point, point), where point is a pair (row, col)
+
+    """
+    return ["%s:%s" % (serialise_point(p1, context),
+                       serialise_point(p2, context))
+            for p1, p2 in values]
+
+
+def interpret_FG(s, context):
+    """Interpret an FG (figure) property value.
+
+    Returns a pair (flags, string), or None.
+
+    flags is an integer; see http://www.red-bean.com/sgf/properties.html#FG
+
+    """
+    if s == "":
+        return None
+    flags, name = sgf_grammar.parse_compose(s)
+    return int(flags), interpret_simpletext(name, context)
+
+def serialise_FG(value, context):
+    """Serialise an FG (figure) property value.
+
+    value -- pair (flags, name), or None
+      flags -- int
+      name  -- string
+
+    Use serialise_FG(None) to produce an empty value.
+
+    """
+    if value is None:
+        return ""
+    flags, name = value
+    return "%d:%s" % (flags, serialise_simpletext(name, context))
+
+
+def interpret_LB_list(values, context):
+    """Interpret an LB (label) property value.
+
+    Returns a list of pairs ((row, col), string).
+
+    """
+    result = []
+    for s in values:
+        point, label = sgf_grammar.parse_compose(s)
+        result.append((interpret_point(point, context),
+                       interpret_simpletext(label, context)))
+    return result
+
+def serialise_LB_list(values, context):
+    """Serialise an LB (label) property value.
+
+    values -- list of pairs ((row, col), string)
+
+    """
+    return ["%s:%s" % (serialise_point(point, context),
+                       serialise_simpletext(text, context))
+            for point, text in values]
+
+
+class Property_type(object):
+    """Description of a property type."""
+    def __init__(self, interpreter, serialiser, uses_list,
+                 allows_empty_list=False):
+        self.interpreter = interpreter
+        self.serialiser = serialiser
+        self.uses_list = bool(uses_list)
+        self.allows_empty_list = bool(allows_empty_list)
+
+def _make_property_type(type_name, allows_empty_list=False):
+    return Property_type(
+        globals()["interpret_" + type_name],
+        globals()["serialise_" + type_name],
+        uses_list=(type_name.endswith("_list")),
+        allows_empty_list=allows_empty_list)
+
+_property_types_by_name = {
+    'none' :        _make_property_type('none'),
+    'number' :      _make_property_type('number'),
+    'real' :        _make_property_type('real'),
+    'double' :      _make_property_type('double'),
+    'colour' :      _make_property_type('colour'),
+    'simpletext' :  _make_property_type('simpletext'),
+    'text' :        _make_property_type('text'),
+    'point' :       _make_property_type('point'),
+    'move' :        _make_property_type('move'),
+    'point_list' :  _make_property_type('point_list'),
+    'point_elist' : _make_property_type('point_list', allows_empty_list=True),
+    'stone_list' :  _make_property_type('point_list'),
+    'AP' :          _make_property_type('AP'),
+    'ARLN_list' :   _make_property_type('ARLN_list'),
+    'FG' :          _make_property_type('FG'),
+    'LB_list' :     _make_property_type('LB_list'),
+}
+
+P = _property_types_by_name
+
+_property_types_by_ident = {
+  'AB' : P['stone_list'],                 # setup         Add Black
+  'AE' : P['point_list'],                 # setup         Add Empty
+  'AN' : P['simpletext'],                 # game-info     Annotation
+  'AP' : P['AP'],                         # root          Application
+  'AR' : P['ARLN_list'],                  # -             Arrow
+  'AW' : P['stone_list'],                 # setup         Add White
+  'B'  : P['move'],                       # move          Black
+  'BL' : P['real'],                       # move          Black time left
+  'BM' : P['double'],                     # move          Bad move
+  'BR' : P['simpletext'],                 # game-info     Black rank
+  'BT' : P['simpletext'],                 # game-info     Black team
+  'C'  : P['text'],                       # -             Comment
+  'CA' : P['simpletext'],                 # root          Charset
+  'CP' : P['simpletext'],                 # game-info     Copyright
+  'CR' : P['point_list'],                 # -             Circle
+  'DD' : P['point_elist'],                # - [inherit]   Dim points
+  'DM' : P['double'],                     # -             Even position
+  'DO' : P['none'],                       # move          Doubtful
+  'DT' : P['simpletext'],                 # game-info     Date
+  'EV' : P['simpletext'],                 # game-info     Event
+  'FF' : P['number'],                     # root          Fileformat
+  'FG' : P['FG'],                         # -             Figure
+  'GB' : P['double'],                     # -             Good for Black
+  'GC' : P['text'],                       # game-info     Game comment
+  'GM' : P['number'],                     # root          Game
+  'GN' : P['simpletext'],                 # game-info     Game name
+  'GW' : P['double'],                     # -             Good for White
+  'HA' : P['number'],                     # game-info     Handicap
+  'HO' : P['double'],                     # -             Hotspot
+  'IT' : P['none'],                       # move          Interesting
+  'KM' : P['real'],                       # game-info     Komi
+  'KO' : P['none'],                       # move          Ko
+  'LB' : P['LB_list'],                    # -             Label
+  'LN' : P['ARLN_list'],                  # -             Line
+  'MA' : P['point_list'],                 # -             Mark
+  'MN' : P['number'],                     # move          set move number
+  'N'  : P['simpletext'],                 # -             Nodename
+  'OB' : P['number'],                     # move          OtStones Black
+  'ON' : P['simpletext'],                 # game-info     Opening
+  'OT' : P['simpletext'],                 # game-info     Overtime
+  'OW' : P['number'],                     # move          OtStones White
+  'PB' : P['simpletext'],                 # game-info     Player Black
+  'PC' : P['simpletext'],                 # game-info     Place
+  'PL' : P['colour'],                     # setup         Player to play
+  'PM' : P['number'],                     # - [inherit]   Print move mode
+  'PW' : P['simpletext'],                 # game-info     Player White
+  'RE' : P['simpletext'],                 # game-info     Result
+  'RO' : P['simpletext'],                 # game-info     Round
+  'RU' : P['simpletext'],                 # game-info     Rules
+  'SL' : P['point_list'],                 # -             Selected
+  'SO' : P['simpletext'],                 # game-info     Source
+  'SQ' : P['point_list'],                 # -             Square
+  'ST' : P['number'],                     # root          Style
+  'SZ' : P['number'],                     # root          Size
+  'TB' : P['point_elist'],                # -             Territory Black
+  'TE' : P['double'],                     # move          Tesuji
+  'TM' : P['real'],                       # game-info     Timelimit
+  'TR' : P['point_list'],                 # -             Triangle
+  'TW' : P['point_elist'],                # -             Territory White
+  'UC' : P['double'],                     # -             Unclear pos
+  'US' : P['simpletext'],                 # game-info     User
+  'V'  : P['real'],                       # -             Value
+  'VW' : P['point_elist'],                # - [inherit]   View
+  'W'  : P['move'],                       # move          White
+  'WL' : P['real'],                       # move          White time left
+  'WR' : P['simpletext'],                 # game-info     White rank
+  'WT' : P['simpletext'],                 # game-info     White team
+}
+_text_property_type = P['text']
+
+del P
+
+
+class Presenter(_Context):
+    """Convert property values between Python and SGF-string representations.
+
+    Instantiate with:
+      size     -- board size (int)
+      encoding -- encoding for the SGF strings
+
+    Public attributes (treat as read-only):
+      size     -- int
+      encoding -- string (normalised form)
+
+    See the _property_types_by_ident table above for a list of properties
+    initially known, and their types.
+
+    Initially, treats unknown (private) properties as if they had type Text.
+
+    """
+
+    def __init__(self, size, encoding):
+        try:
+            encoding = normalise_charset_name(encoding)
+        except LookupError:
+            raise ValueError("unknown encoding: %s" % encoding)
+        _Context.__init__(self, size, encoding)
+        self.property_types_by_ident = _property_types_by_ident.copy()
+        self.default_property_type = _text_property_type
+
+    def get_property_type(self, identifier):
+        """Return the Property_type for the specified PropIdent.
+
+        Rasies KeyError if the property is unknown.
+
+        """
+        return self.property_types_by_ident[identifier]
+
+    def register_property(self, identifier, property_type):
+        """Specify the Property_type for a PropIdent."""
+        self.property_types_by_ident[identifier] = property_type
+
+    def deregister_property(self, identifier):
+        """Forget the type for the specified PropIdent."""
+        del self.property_types_by_ident[identifier]
+
+    def set_private_property_type(self, property_type):
+        """Specify the Property_type to use for unknown properties.
+
+        Pass property_type = None to make unknown properties raise an error.
+
+        """
+        self.default_property_type = property_type
+
+    def _get_effective_property_type(self, identifier):
+        try:
+            return self.property_types_by_ident[identifier]
+        except KeyError:
+            result = self.default_property_type
+            if result is None:
+                raise ValueError("unknown property")
+            return result
+
+    def interpret_as_type(self, property_type, raw_values):
+        """Variant of interpret() for explicitly specified type.
+
+        property_type -- Property_type
+
+        """
+        if not raw_values:
+            raise ValueError("no raw values")
+        if property_type.uses_list:
+            if raw_values == [""]:
+                raw = []
+            else:
+                raw = raw_values
+        else:
+            if len(raw_values) > 1:
+                raise ValueError("multiple values")
+            raw = raw_values[0]
+        return property_type.interpreter(raw, self)
+
+    def interpret(self, identifier, raw_values):
+        """Return a Python representation of a property value.
+
+        identifier -- PropIdent
+        raw_values -- nonempty list of 8-bit strings in the presenter's encoding
+
+        See the interpret_... functions above for details of how values are
+        represented as Python types.
+
+        Raises ValueError if it cannot interpret the value.
+
+        Note that in some cases the interpret_... functions accept values which
+        are not strictly permitted by the specification.
+
+        elist handling: if the property's value type is a list type and
+        'raw_values' is a list containing a single empty string, passes an
+        empty list to the interpret_... function (that is, this function treats
+        all lists like elists).
+
+        Doesn't enforce range restrictions on values with type Number.
+
+        """
+        return self.interpret_as_type(
+            self._get_effective_property_type(identifier), raw_values)
+
+    def serialise_as_type(self, property_type, value):
+        """Variant of serialise() for explicitly specified type.
+
+        property_type -- Property_type
+
+        """
+        serialised = property_type.serialiser(value, self)
+        if property_type.uses_list:
+            if serialised == []:
+                if property_type.allows_empty_list:
+                    return [""]
+                else:
+                    raise ValueError("empty list")
+            return serialised
+        else:
+            return [serialised]
+
+    def serialise(self, identifier, value):
+        """Serialise a Python representation of a property value.
+
+        identifier -- PropIdent
+        value      -- corresponding Python value
+
+        Returns a nonempty list of 8-bit strings in the presenter's encoding,
+        suitable for use as raw PropValues.
+
+        See the serialise_... functions above for details of the acceptable
+        values for each type.
+
+        elist handling: if the property's value type is an elist type and the
+        serialise_... function returns an empty list, this returns a list
+        containing a single empty string.
+
+        Raises ValueError if it cannot serialise the value.
+
+        In general, the serialise_... functions try not to produce an invalid
+        result, but do not try to prevent garbage input happening to produce a
+        valid result.
+
+        """
+        return self.serialise_as_type(
+            self._get_effective_property_type(identifier), value)

--- a/betago/gosgf/sgf_properties.py
+++ b/betago/gosgf/sgf_properties.py
@@ -425,8 +425,7 @@ def serialise_ARLN_list(values, context):
     values -- list of pairs (point, point), where point is a pair (row, col)
 
     """
-    return [b"%s:%s" % (serialise_point(p1, context),
-                        serialise_point(p2, context))
+    return [b":".join((serialise_point(p1, context), serialise_point(p2, context)))
             for p1, p2 in values]
 
 
@@ -456,7 +455,7 @@ def serialise_FG(value, context):
     if value is None:
         return b""
     flags, name = value
-    return b"%d:%s" % (flags, serialise_simpletext(name, context))
+    return str(flags).encode('ascii') + b":" + serialise_simpletext(name, context)
 
 
 def interpret_LB_list(values, context):
@@ -478,8 +477,7 @@ def serialise_LB_list(values, context):
     values -- list of pairs ((row, col), string)
 
     """
-    return [b"%s:%s" % (serialise_point(point, context),
-                        serialise_simpletext(text, context))
+    return [b":".join((serialise_point(point, context), serialise_simpletext(text, context)))
             for point, text in values]
 
 

--- a/betago/gosgf/sgf_properties.py
+++ b/betago/gosgf/sgf_properties.py
@@ -16,6 +16,13 @@ import six
 
 from . import sgf_grammar
 
+# In python 2, indexing a str gives one-character strings.
+# In python 3, indexing a bytes gives ints.
+if six.PY2:
+    _bytestring_ord = ord
+else:
+    _bytestring_ord = lambda x: x
+
 def normalise_charset_name(s):
     """Convert an encoding name to the form implied in the SGF spec.
 
@@ -51,8 +58,8 @@ def interpret_go_point(s, size):
         return None
     # May propagate ValueError
     col_s, row_s = s
-    col = col_s - 97 # 97 == ord("a")
-    row = size - row_s + 96
+    col = _bytestring_ord(col_s) - 97 # 97 == ord("a")
+    row = size - _bytestring_ord(row_s) + 96
     if not ((0 <= col < size) and (0 <= row < size)):
         raise ValueError
     return row, col

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(name='betago',
       download_url='https://github.com/maxpumperla/betago/tarball/0.2',
       author='Max Pumperla',
       author_email='max.pumperla@googlemail.com',
-      install_requires=['keras', 'gomill', 'Flask>=0.10.1', 'Flask-Cors', 'future', 'h5py'],
+      install_requires=['keras', 'gomill', 'Flask>=0.10.1', 'Flask-Cors', 'future', 'h5py', 'six'],
       license='MIT',
       packages=find_packages(),
       zip_safe=False)

--- a/tests/gosgf/sgf_grammar_test.py
+++ b/tests/gosgf/sgf_grammar_test.py
@@ -1,0 +1,359 @@
+"""Tests for sgf_grammar.py."""
+
+import unittest
+
+from betago.gosgf import sgf_grammar
+
+
+class SgfGrammarTestCase(unittest.TestCase):
+    def test_is_valid_property_identifier(tc):
+        ivpi = sgf_grammar.is_valid_property_identifier
+        tc.assertIs(ivpi("B"), True)
+        tc.assertIs(ivpi("PB"), True)
+        tc.assertIs(ivpi("ABCDEFGH"), True)
+        tc.assertIs(ivpi("ABCDEFGHI"), False)
+        tc.assertIs(ivpi(""), False)
+        tc.assertIs(ivpi("b"), False)
+        tc.assertIs(ivpi("Player"), False)
+        tc.assertIs(ivpi("P2"), False)
+        tc.assertIs(ivpi(" PB"), False)
+        tc.assertIs(ivpi("PB "), False)
+        tc.assertIs(ivpi("P B"), False)
+        tc.assertIs(ivpi("PB\x00"), False)
+
+    def test_is_valid_property_value(tc):
+        ivpv = sgf_grammar.is_valid_property_value
+        tc.assertIs(ivpv(""), True)
+        tc.assertIs(ivpv("hello world"), True)
+        tc.assertIs(ivpv("hello\nworld"), True)
+        tc.assertIs(ivpv("hello \x00 world"), True)
+        tc.assertIs(ivpv("hello \xa3 world"), True)
+        tc.assertIs(ivpv("hello \xc2\xa3 world"), True)
+        tc.assertIs(ivpv("hello \\-) world"), True)
+        tc.assertIs(ivpv("hello (;[) world"), True)
+        tc.assertIs(ivpv("[hello world]"), False)
+        tc.assertIs(ivpv("hello ] world"), False)
+        tc.assertIs(ivpv("hello \\] world"), True)
+        tc.assertIs(ivpv("hello world \\"), False)
+        tc.assertIs(ivpv("hello world \\\\"), True)
+        tc.assertIs(ivpv("x" * 70000), True)
+
+    def test_tokeniser(tc):
+        tokenise = sgf_grammar.tokenise
+
+        tc.assertEqual(tokenise("(;B[ah][]C[a\xa3b])")[0],
+                       [('D', '('),
+                        ('D', ';'),
+                        ('I', 'B'),
+                        ('V', 'ah'),
+                        ('V', ''),
+                        ('I', 'C'),
+                        ('V', 'a\xa3b'),
+                        ('D', ')')])
+
+        def check_complete(s, *args):
+            tokens, tail_index = tokenise(s, *args)
+            tc.assertEqual(tail_index, len(s))
+            return len(tokens)
+
+        def check_incomplete(s, *args):
+            tokens, tail_index = tokenise(s, *args)
+            return len(tokens), tail_index
+
+        # check surrounding junk
+        tc.assertEqual(check_complete(""), 0)
+        tc.assertEqual(check_complete("junk (;B[ah])"), 5)
+        tc.assertEqual(check_incomplete("junk"), (0, 0))
+        tc.assertEqual(check_incomplete("junk (B[ah])"), (0, 0))
+        tc.assertEqual(check_incomplete("(;B[ah]) junk"), (5, 8))
+
+        # check paren-balance count
+        tc.assertEqual(check_incomplete("(; ))(([ag]B C[ah])"), (3, 4))
+        tc.assertEqual(check_incomplete("(;( )) (;)"), (5, 6))
+        tc.assertEqual(check_incomplete("(;(()())) (;)"), (9, 9))
+
+        # check start_position
+        tc.assertEqual(check_complete("(; ))(;B[ah])", 4), 5)
+        tc.assertEqual(check_complete("(; ))junk (;B[ah])", 4), 5)
+
+        tc.assertEqual(check_complete("(;XX[abc][def]KO[];B[bc])"), 11)
+        tc.assertEqual(check_complete("( ;XX[abc][def]KO[];B[bc])"), 11)
+        tc.assertEqual(check_complete("(; XX[abc][def]KO[];B[bc])"), 11)
+        tc.assertEqual(check_complete("(;XX [abc][def]KO[];B[bc])"), 11)
+        tc.assertEqual(check_complete("(;XX[abc] [def]KO[];B[bc])"), 11)
+        tc.assertEqual(check_complete("(;XX[abc][def] KO[];B[bc])"), 11)
+        tc.assertEqual(check_complete("(;XX[abc][def]KO [];B[bc])"), 11)
+        tc.assertEqual(check_complete("(;XX[abc][def]KO[] ;B[bc])"), 11)
+        tc.assertEqual(check_complete("(;XX[abc][def]KO[]; B[bc])"), 11)
+        tc.assertEqual(check_complete("(;XX[abc][def]KO[];B [bc])"), 11)
+        tc.assertEqual(check_complete("(;XX[abc][def]KO[];B[bc] )"), 11)
+
+        tc.assertEqual(check_complete("( ;\nB\t[ah]\f[ef]\v)"), 6)
+        tc.assertEqual(check_complete("(;[Ran\xc2\xa3dom :\nstu@ff][ef]"), 4)
+        tc.assertEqual(check_complete("(;[ah)])"), 4)
+
+        tc.assertEqual(check_incomplete("(;B[ag"), (3, 3))
+        tc.assertEqual(check_incomplete("(;B[ag)"), (3, 3))
+        tc.assertEqual(check_incomplete("(;AddBlack[ag])"), (3, 3))
+        tc.assertEqual(check_incomplete("(;+B[ag])"), (2, 2))
+        tc.assertEqual(check_incomplete("(;B+[ag])"), (3, 3))
+        tc.assertEqual(check_incomplete("(;B[ag]+)"), (4, 7))
+
+        tc.assertEqual(check_complete(r"(;[ab \] cd][ef]"), 4)
+        tc.assertEqual(check_complete(r"(;[ab \] cd\\][ef]"), 4)
+        tc.assertEqual(check_complete(r"(;[ab \] cd\\\\][ef]"), 4)
+        tc.assertEqual(check_complete(r"(;[ab \] \\\] cd][ef]"), 4)
+        tc.assertEqual(check_incomplete(r"(;B[ag\])"), (3, 3))
+        tc.assertEqual(check_incomplete(r"(;B[ag\\\])"), (3, 3))
+
+    def test_parser_structure(tc):
+        parse_sgf_game = sgf_grammar.parse_sgf_game
+
+        def shape(s):
+            coarse_game = parse_sgf_game(s)
+            return len(coarse_game.sequence), len(coarse_game.children)
+
+        tc.assertEqual(shape("(;C[abc]KO[];B[bc])"), (2, 0))
+        tc.assertEqual(shape("initial junk (;C[abc]KO[];B[bc])"), (2, 0))
+        tc.assertEqual(shape("(;C[abc]KO[];B[bc]) final junk"), (2, 0))
+        tc.assertEqual(shape("(;C[abc]KO[];B[bc]) (;B[ag])"), (2, 0))
+
+        tc.assertRaisesRegexp(ValueError, "no SGF data found",
+                              parse_sgf_game, r"")
+        tc.assertRaisesRegexp(ValueError, "no SGF data found",
+                              parse_sgf_game, r"junk")
+        tc.assertRaisesRegexp(ValueError, "no SGF data found",
+                              parse_sgf_game, r"()")
+        tc.assertRaisesRegexp(ValueError, "no SGF data found",
+                              parse_sgf_game, r"(B[ag])")
+        tc.assertRaisesRegexp(ValueError, "no SGF data found",
+                              parse_sgf_game, r"B[ag]")
+        tc.assertRaisesRegexp(ValueError, "no SGF data found",
+                              parse_sgf_game, r"[ag]")
+
+        tc.assertEqual(shape("(;C[abc]AB[ab][bc];B[bc])"), (2, 0))
+        tc.assertEqual(shape("(;C[abc] AB[ab]\n[bc]\t;B[bc])"), (2, 0))
+        tc.assertEqual(shape("(;C[abc]KO[];;B[bc])"), (3, 0))
+        tc.assertEqual(shape("(;)"), (1, 0))
+
+        tc.assertRaisesRegexp(ValueError, "property with no values",
+                              parse_sgf_game, r"(;B)")
+        tc.assertRaisesRegexp(ValueError, "unexpected value",
+                              parse_sgf_game, r"(;[ag])")
+        tc.assertRaisesRegexp(ValueError, "unexpected value",
+                              parse_sgf_game, r"(;[ag][ah])")
+        tc.assertRaisesRegexp(ValueError, "unexpected value",
+                              parse_sgf_game, r"(;[B][ag])")
+        tc.assertRaisesRegexp(ValueError, "unexpected end of SGF data",
+                              parse_sgf_game, r"(;B[ag]")
+        tc.assertRaisesRegexp(ValueError, "unexpected end of SGF data",
+                              parse_sgf_game, r"(;B[ag][)]")
+        tc.assertRaisesRegexp(ValueError, "property with no values",
+                              parse_sgf_game, r"(;B;W[ah])")
+        tc.assertRaisesRegexp(ValueError, "unexpected value",
+                              parse_sgf_game, r"(;B[ag](;[ah]))")
+        tc.assertRaisesRegexp(ValueError, "property with no values",
+                              parse_sgf_game, r"(;B W[ag])")
+
+    def test_parser_tree_structure(tc):
+        parse_sgf_game = sgf_grammar.parse_sgf_game
+
+        def shape(s):
+            coarse_game = parse_sgf_game(s)
+            return len(coarse_game.sequence), len(coarse_game.children)
+
+        tc.assertEqual(shape("(;C[abc]AB[ab](;B[bc]))"), (1, 1))
+        tc.assertEqual(shape("(;C[abc]AB[ab](;B[bc])))"), (1, 1))
+        tc.assertEqual(shape("(;C[abc]AB[ab](;B[bc])(;B[bd]))"), (1, 2))
+
+        def shapetree(s):
+            def _shapetree(coarse_game):
+                return (
+                    len(coarse_game.sequence),
+                    [_shapetree(pg) for pg in coarse_game.children])
+            return _shapetree(parse_sgf_game(s))
+
+        tc.assertEqual(shapetree("(;C[abc]AB[ab](;B[bc])))"),
+                       (1, [(1, [])])
+                       )
+        tc.assertEqual(shapetree("(;C[abc]AB[ab](;B[bc]))))"),
+                       (1, [(1, [])])
+                       )
+        tc.assertEqual(shapetree("(;C[abc]AB[ab](;B[bc])(;B[bd])))"),
+                       (1, [(1, []), (1, [])])
+                       )
+        tc.assertEqual(shapetree("""
+            (;C[abc]AB[ab];C[];C[]
+              (;B[bc])
+              (;B[bd];W[ca] (;B[da])(;B[db];W[ea]) )
+            )"""),
+            (3, [
+                (1, []),
+                (2, [(1, []), (2, [])])
+            ])
+        )
+
+        tc.assertRaisesRegexp(ValueError, "unexpected end of SGF data",
+                              parse_sgf_game, "(;B[ag];W[ah](;B[ai])")
+        tc.assertRaisesRegexp(ValueError, "empty sequence",
+                              parse_sgf_game, "(;B[ag];())")
+        tc.assertRaisesRegexp(ValueError, "empty sequence",
+                              parse_sgf_game, "(;B[ag]())")
+        tc.assertRaisesRegexp(ValueError, "empty sequence",
+                              parse_sgf_game, "(;B[ag]((;W[ah])(;W[ai]))")
+        tc.assertRaisesRegexp(ValueError, "unexpected node",
+                              parse_sgf_game, "(;B[ag];W[ah](;B[ai]);W[bd])")
+        tc.assertRaisesRegexp(ValueError, "property value outside a node",
+                              parse_sgf_game, "(;B[ag];(W[ah];B[ai]))")
+        tc.assertRaisesRegexp(ValueError, "property value outside a node",
+                              parse_sgf_game, "(;B[ag](;W[ah];)B[ai])")
+        tc.assertRaisesRegexp(ValueError, "property value outside a node",
+                              parse_sgf_game, "(;B[ag](;W[ah])(B[ai]))")
+
+    def test_parser_properties(tc):
+        parse_sgf_game = sgf_grammar.parse_sgf_game
+
+        def props(s):
+            coarse_game = parse_sgf_game(s)
+            return coarse_game.sequence
+
+        tc.assertEqual(props("(;C[abc]KO[]AB[ai][bh][ee];B[ bc])"),
+                       [{'C': ['abc'], 'KO': [''], 'AB': ['ai', 'bh', 'ee']},
+                        {'B': [' bc']}])
+
+        tc.assertEqual(props(r"(;C[ab \] \) cd\\])"),
+                       [{'C': [r"ab \] \) cd\\"]}])
+
+        tc.assertEqual(props("(;XX[1]YY[2]XX[3]YY[4])"),
+                       [{'XX': ['1', '3'], 'YY' : ['2', '4']}])
+
+    def test_parse_sgf_collection(tc):
+        parse_sgf_collection = sgf_grammar.parse_sgf_collection
+
+        tc.assertRaisesRegexp(ValueError, "no SGF data found",
+                              parse_sgf_collection, r"")
+        tc.assertRaisesRegexp(ValueError, "no SGF data found",
+                              parse_sgf_collection, r"()")
+
+        games = parse_sgf_collection("(;C[abc]AB[ab];X[];X[](;B[bc]))")
+        tc.assertEqual(len(games), 1)
+        tc.assertEqual(len(games[0].sequence), 3)
+
+        games = parse_sgf_collection("(;X[1];X[2];X[3](;B[bc])) (;Y[1];Y[2])")
+        tc.assertEqual(len(games), 2)
+        tc.assertEqual(len(games[0].sequence), 3)
+        tc.assertEqual(len(games[1].sequence), 2)
+
+        games = parse_sgf_collection(
+            "dummy (;X[1];X[2];X[3](;B[bc])) junk (;Y[1];Y[2]) Nonsense")
+        tc.assertEqual(len(games), 2)
+        tc.assertEqual(len(games[0].sequence), 3)
+        tc.assertEqual(len(games[1].sequence), 2)
+
+        games = parse_sgf_collection(
+            "(( (;X[1];X[2];X[3](;B[bc])) ();) (;Y[1];Y[2]) )(Nonsense")
+        tc.assertEqual(len(games), 2)
+        tc.assertEqual(len(games[0].sequence), 3)
+        tc.assertEqual(len(games[1].sequence), 2)
+
+        with tc.assertRaises(ValueError) as ar:
+            parse_sgf_collection(
+                "(( (;X[1];X[2];X[3](;B[bc])) ();) (;Y[1];Y[2]")
+        tc.assertEqual(str(ar.exception),
+                       "error parsing game 1: unexpected end of SGF data")
+
+
+    def test_parse_compose(tc):
+        pc = sgf_grammar.parse_compose
+        tc.assertEqual(pc("word"), ("word", None))
+        tc.assertEqual(pc("word:"), ("word", ""))
+        tc.assertEqual(pc("word:?"), ("word", "?"))
+        tc.assertEqual(pc("word:123"), ("word", "123"))
+        tc.assertEqual(pc("word:123:456"), ("word", "123:456"))
+        tc.assertEqual(pc(":123"), ("", "123"))
+        tc.assertEqual(pc(r"word\:more"), (r"word\:more", None))
+        tc.assertEqual(pc(r"word\:more:?"), (r"word\:more", "?"))
+        tc.assertEqual(pc(r"word\\:more:?"), ("word\\\\", "more:?"))
+        tc.assertEqual(pc(r"word\\\:more:?"), (r"word\\\:more", "?"))
+        tc.assertEqual(pc("word\\\nmore:123"), ("word\\\nmore", "123"))
+
+    def test_text_value(tc):
+        text_value = sgf_grammar.text_value
+        tc.assertEqual(text_value("abc "), "abc ")
+        tc.assertEqual(text_value("ab c"), "ab c")
+        tc.assertEqual(text_value("ab\tc"), "ab c")
+        tc.assertEqual(text_value("ab \tc"), "ab  c")
+        tc.assertEqual(text_value("ab\nc"), "ab\nc")
+        tc.assertEqual(text_value("ab\\\nc"), "abc")
+        tc.assertEqual(text_value("ab\\\\\nc"), "ab\\\nc")
+        tc.assertEqual(text_value("ab\xa0c"), "ab\xa0c")
+
+        tc.assertEqual(text_value("ab\rc"), "ab\nc")
+        tc.assertEqual(text_value("ab\r\nc"), "ab\nc")
+        tc.assertEqual(text_value("ab\n\rc"), "ab\nc")
+        tc.assertEqual(text_value("ab\r\n\r\nc"), "ab\n\nc")
+        tc.assertEqual(text_value("ab\r\n\r\n\rc"), "ab\n\n\nc")
+        tc.assertEqual(text_value("ab\\\r\nc"), "abc")
+        tc.assertEqual(text_value("ab\\\n\nc"), "ab\nc")
+
+        tc.assertEqual(text_value("ab\\\tc"), "ab c")
+
+        # These can't actually appear as SGF PropValues; anything sane will do
+        tc.assertEqual(text_value("abc\\"), "abc")
+        tc.assertEqual(text_value("abc]"), "abc]")
+
+    def test_simpletext_value(tc):
+        simpletext_value = sgf_grammar.simpletext_value
+        tc.assertEqual(simpletext_value("abc "), "abc ")
+        tc.assertEqual(simpletext_value("ab c"), "ab c")
+        tc.assertEqual(simpletext_value("ab\tc"), "ab c")
+        tc.assertEqual(simpletext_value("ab \tc"), "ab  c")
+        tc.assertEqual(simpletext_value("ab\nc"), "ab c")
+        tc.assertEqual(simpletext_value("ab\\\nc"), "abc")
+        tc.assertEqual(simpletext_value("ab\\\\\nc"), "ab\\ c")
+        tc.assertEqual(simpletext_value("ab\xa0c"), "ab\xa0c")
+
+        tc.assertEqual(simpletext_value("ab\rc"), "ab c")
+        tc.assertEqual(simpletext_value("ab\r\nc"), "ab c")
+        tc.assertEqual(simpletext_value("ab\n\rc"), "ab c")
+        tc.assertEqual(simpletext_value("ab\r\n\r\nc"), "ab  c")
+        tc.assertEqual(simpletext_value("ab\r\n\r\n\rc"), "ab   c")
+        tc.assertEqual(simpletext_value("ab\\\r\nc"), "abc")
+        tc.assertEqual(simpletext_value("ab\\\n\nc"), "ab c")
+
+        tc.assertEqual(simpletext_value("ab\\\tc"), "ab c")
+
+        # These can't actually appear as SGF PropValues; anything sane will do
+        tc.assertEqual(simpletext_value("abc\\"), "abc")
+        tc.assertEqual(simpletext_value("abc]"), "abc]")
+
+    def test_escape_text(tc):
+        tc.assertEqual(sgf_grammar.escape_text("abc"), "abc")
+        tc.assertEqual(sgf_grammar.escape_text(r"a\bc"), r"a\\bc")
+        tc.assertEqual(sgf_grammar.escape_text(r"ab[c]"), r"ab[c\]")
+        tc.assertEqual(sgf_grammar.escape_text(r"a\]bc"), r"a\\\]bc")
+
+    def test_text_roundtrip(tc):
+        def roundtrip(s):
+            return sgf_grammar.text_value(sgf_grammar.escape_text(s))
+        tc.assertEqual(roundtrip(r"abc"), r"abc")
+        tc.assertEqual(roundtrip(r"a\bc"), r"a\bc")
+        tc.assertEqual(roundtrip("abc\\"), "abc\\")
+        tc.assertEqual(roundtrip("ab]c"), "ab]c")
+        tc.assertEqual(roundtrip("abc]"), "abc]")
+        tc.assertEqual(roundtrip(r"abc\]"), r"abc\]")
+        tc.assertEqual(roundtrip("ab\nc"), "ab\nc")
+        tc.assertEqual(roundtrip("ab\n  c"), "ab\n  c")
+
+        tc.assertEqual(roundtrip("ab\tc"), "ab c")
+        tc.assertEqual(roundtrip("ab\r\nc\n"), "ab\nc\n")
+
+    def test_serialise_game_tree(tc):
+        serialised = ("(;AB[aa][ab][ac]C[comment \xa3];W[ab];C[];C[]"
+                      "(;B[bc])(;B[bd];W[ca](;B[da])(;B[db];\n"
+                      "W[ea])))\n")
+        coarse_game = sgf_grammar.parse_sgf_game(serialised)
+        tc.assertEqual(sgf_grammar.serialise_game_tree(coarse_game), serialised)
+        tc.assertEqual(sgf_grammar.serialise_game_tree(coarse_game, wrap=None),
+                       serialised.replace("\n", "")+"\n")
+

--- a/tests/gosgf/sgf_grammar_test.py
+++ b/tests/gosgf/sgf_grammar_test.py
@@ -8,48 +8,48 @@ from betago.gosgf import sgf_grammar
 class SgfGrammarTestCase(unittest.TestCase):
     def test_is_valid_property_identifier(tc):
         ivpi = sgf_grammar.is_valid_property_identifier
-        tc.assertIs(ivpi("B"), True)
-        tc.assertIs(ivpi("PB"), True)
-        tc.assertIs(ivpi("ABCDEFGH"), True)
-        tc.assertIs(ivpi("ABCDEFGHI"), False)
-        tc.assertIs(ivpi(""), False)
-        tc.assertIs(ivpi("b"), False)
-        tc.assertIs(ivpi("Player"), False)
-        tc.assertIs(ivpi("P2"), False)
-        tc.assertIs(ivpi(" PB"), False)
-        tc.assertIs(ivpi("PB "), False)
-        tc.assertIs(ivpi("P B"), False)
-        tc.assertIs(ivpi("PB\x00"), False)
+        tc.assertIs(ivpi(b"B"), True)
+        tc.assertIs(ivpi(b"PB"), True)
+        tc.assertIs(ivpi(b"ABCDEFGH"), True)
+        tc.assertIs(ivpi(b"ABCDEFGHI"), False)
+        tc.assertIs(ivpi(b""), False)
+        tc.assertIs(ivpi(b"b"), False)
+        tc.assertIs(ivpi(b"Player"), False)
+        tc.assertIs(ivpi(b"P2"), False)
+        tc.assertIs(ivpi(b" PB"), False)
+        tc.assertIs(ivpi(b"PB "), False)
+        tc.assertIs(ivpi(b"P B"), False)
+        tc.assertIs(ivpi(b"PB\x00"), False)
 
     def test_is_valid_property_value(tc):
         ivpv = sgf_grammar.is_valid_property_value
-        tc.assertIs(ivpv(""), True)
-        tc.assertIs(ivpv("hello world"), True)
-        tc.assertIs(ivpv("hello\nworld"), True)
-        tc.assertIs(ivpv("hello \x00 world"), True)
-        tc.assertIs(ivpv("hello \xa3 world"), True)
-        tc.assertIs(ivpv("hello \xc2\xa3 world"), True)
-        tc.assertIs(ivpv("hello \\-) world"), True)
-        tc.assertIs(ivpv("hello (;[) world"), True)
-        tc.assertIs(ivpv("[hello world]"), False)
-        tc.assertIs(ivpv("hello ] world"), False)
-        tc.assertIs(ivpv("hello \\] world"), True)
-        tc.assertIs(ivpv("hello world \\"), False)
-        tc.assertIs(ivpv("hello world \\\\"), True)
-        tc.assertIs(ivpv("x" * 70000), True)
+        tc.assertIs(ivpv(b""), True)
+        tc.assertIs(ivpv(b"hello world"), True)
+        tc.assertIs(ivpv(b"hello\nworld"), True)
+        tc.assertIs(ivpv(b"hello \x00 world"), True)
+        tc.assertIs(ivpv(b"hello \xa3 world"), True)
+        tc.assertIs(ivpv(b"hello \xc2\xa3 world"), True)
+        tc.assertIs(ivpv(b"hello \\-) world"), True)
+        tc.assertIs(ivpv(b"hello (;[) world"), True)
+        tc.assertIs(ivpv(b"[hello world]"), False)
+        tc.assertIs(ivpv(b"hello ] world"), False)
+        tc.assertIs(ivpv(b"hello \\] world"), True)
+        tc.assertIs(ivpv(b"hello world \\"), False)
+        tc.assertIs(ivpv(b"hello world \\\\"), True)
+        tc.assertIs(ivpv(b"x" * 70000), True)
 
     def test_tokeniser(tc):
         tokenise = sgf_grammar.tokenise
 
-        tc.assertEqual(tokenise("(;B[ah][]C[a\xa3b])")[0],
-                       [('D', '('),
-                        ('D', ';'),
-                        ('I', 'B'),
-                        ('V', 'ah'),
-                        ('V', ''),
-                        ('I', 'C'),
-                        ('V', 'a\xa3b'),
-                        ('D', ')')])
+        tc.assertEqual(tokenise(b"(;B[ah][]C[a\xa3b])")[0],
+                       [('D', b'('),
+                        ('D', b';'),
+                        ('I', b'B'),
+                        ('V', b'ah'),
+                        ('V', b''),
+                        ('I', b'C'),
+                        ('V', b'a\xa3b'),
+                        ('D', b')')])
 
         def check_complete(s, *args):
             tokens, tail_index = tokenise(s, *args)
@@ -61,50 +61,50 @@ class SgfGrammarTestCase(unittest.TestCase):
             return len(tokens), tail_index
 
         # check surrounding junk
-        tc.assertEqual(check_complete(""), 0)
-        tc.assertEqual(check_complete("junk (;B[ah])"), 5)
-        tc.assertEqual(check_incomplete("junk"), (0, 0))
-        tc.assertEqual(check_incomplete("junk (B[ah])"), (0, 0))
-        tc.assertEqual(check_incomplete("(;B[ah]) junk"), (5, 8))
+        tc.assertEqual(check_complete(b""), 0)
+        tc.assertEqual(check_complete(b"junk (;B[ah])"), 5)
+        tc.assertEqual(check_incomplete(b"junk"), (0, 0))
+        tc.assertEqual(check_incomplete(b"junk (B[ah])"), (0, 0))
+        tc.assertEqual(check_incomplete(b"(;B[ah]) junk"), (5, 8))
 
         # check paren-balance count
-        tc.assertEqual(check_incomplete("(; ))(([ag]B C[ah])"), (3, 4))
-        tc.assertEqual(check_incomplete("(;( )) (;)"), (5, 6))
-        tc.assertEqual(check_incomplete("(;(()())) (;)"), (9, 9))
+        tc.assertEqual(check_incomplete(b"(; ))(([ag]B C[ah])"), (3, 4))
+        tc.assertEqual(check_incomplete(b"(;( )) (;)"), (5, 6))
+        tc.assertEqual(check_incomplete(b"(;(()())) (;)"), (9, 9))
 
         # check start_position
-        tc.assertEqual(check_complete("(; ))(;B[ah])", 4), 5)
-        tc.assertEqual(check_complete("(; ))junk (;B[ah])", 4), 5)
+        tc.assertEqual(check_complete(b"(; ))(;B[ah])", 4), 5)
+        tc.assertEqual(check_complete(b"(; ))junk (;B[ah])", 4), 5)
 
-        tc.assertEqual(check_complete("(;XX[abc][def]KO[];B[bc])"), 11)
-        tc.assertEqual(check_complete("( ;XX[abc][def]KO[];B[bc])"), 11)
-        tc.assertEqual(check_complete("(; XX[abc][def]KO[];B[bc])"), 11)
-        tc.assertEqual(check_complete("(;XX [abc][def]KO[];B[bc])"), 11)
-        tc.assertEqual(check_complete("(;XX[abc] [def]KO[];B[bc])"), 11)
-        tc.assertEqual(check_complete("(;XX[abc][def] KO[];B[bc])"), 11)
-        tc.assertEqual(check_complete("(;XX[abc][def]KO [];B[bc])"), 11)
-        tc.assertEqual(check_complete("(;XX[abc][def]KO[] ;B[bc])"), 11)
-        tc.assertEqual(check_complete("(;XX[abc][def]KO[]; B[bc])"), 11)
-        tc.assertEqual(check_complete("(;XX[abc][def]KO[];B [bc])"), 11)
-        tc.assertEqual(check_complete("(;XX[abc][def]KO[];B[bc] )"), 11)
+        tc.assertEqual(check_complete(b"(;XX[abc][def]KO[];B[bc])"), 11)
+        tc.assertEqual(check_complete(b"( ;XX[abc][def]KO[];B[bc])"), 11)
+        tc.assertEqual(check_complete(b"(; XX[abc][def]KO[];B[bc])"), 11)
+        tc.assertEqual(check_complete(b"(;XX [abc][def]KO[];B[bc])"), 11)
+        tc.assertEqual(check_complete(b"(;XX[abc] [def]KO[];B[bc])"), 11)
+        tc.assertEqual(check_complete(b"(;XX[abc][def] KO[];B[bc])"), 11)
+        tc.assertEqual(check_complete(b"(;XX[abc][def]KO [];B[bc])"), 11)
+        tc.assertEqual(check_complete(b"(;XX[abc][def]KO[] ;B[bc])"), 11)
+        tc.assertEqual(check_complete(b"(;XX[abc][def]KO[]; B[bc])"), 11)
+        tc.assertEqual(check_complete(b"(;XX[abc][def]KO[];B [bc])"), 11)
+        tc.assertEqual(check_complete(b"(;XX[abc][def]KO[];B[bc] )"), 11)
 
-        tc.assertEqual(check_complete("( ;\nB\t[ah]\f[ef]\v)"), 6)
-        tc.assertEqual(check_complete("(;[Ran\xc2\xa3dom :\nstu@ff][ef]"), 4)
-        tc.assertEqual(check_complete("(;[ah)])"), 4)
+        tc.assertEqual(check_complete(b"( ;\nB\t[ah]\f[ef]\v)"), 6)
+        tc.assertEqual(check_complete(b"(;[Ran\xc2\xa3dom :\nstu@ff][ef]"), 4)
+        tc.assertEqual(check_complete(b"(;[ah)])"), 4)
 
-        tc.assertEqual(check_incomplete("(;B[ag"), (3, 3))
-        tc.assertEqual(check_incomplete("(;B[ag)"), (3, 3))
-        tc.assertEqual(check_incomplete("(;AddBlack[ag])"), (3, 3))
-        tc.assertEqual(check_incomplete("(;+B[ag])"), (2, 2))
-        tc.assertEqual(check_incomplete("(;B+[ag])"), (3, 3))
-        tc.assertEqual(check_incomplete("(;B[ag]+)"), (4, 7))
+        tc.assertEqual(check_incomplete(b"(;B[ag"), (3, 3))
+        tc.assertEqual(check_incomplete(b"(;B[ag)"), (3, 3))
+        tc.assertEqual(check_incomplete(b"(;AddBlack[ag])"), (3, 3))
+        tc.assertEqual(check_incomplete(b"(;+B[ag])"), (2, 2))
+        tc.assertEqual(check_incomplete(b"(;B+[ag])"), (3, 3))
+        tc.assertEqual(check_incomplete(b"(;B[ag]+)"), (4, 7))
 
-        tc.assertEqual(check_complete(r"(;[ab \] cd][ef]"), 4)
-        tc.assertEqual(check_complete(r"(;[ab \] cd\\][ef]"), 4)
-        tc.assertEqual(check_complete(r"(;[ab \] cd\\\\][ef]"), 4)
-        tc.assertEqual(check_complete(r"(;[ab \] \\\] cd][ef]"), 4)
-        tc.assertEqual(check_incomplete(r"(;B[ag\])"), (3, 3))
-        tc.assertEqual(check_incomplete(r"(;B[ag\\\])"), (3, 3))
+        tc.assertEqual(check_complete(r"(;[ab \] cd][ef]".encode('ascii')), 4)
+        tc.assertEqual(check_complete(r"(;[ab \] cd\\][ef]".encode('ascii')), 4)
+        tc.assertEqual(check_complete(r"(;[ab \] cd\\\\][ef]".encode('ascii')), 4)
+        tc.assertEqual(check_complete(r"(;[ab \] \\\] cd][ef]".encode('ascii')), 4)
+        tc.assertEqual(check_incomplete(r"(;B[ag\])".encode('ascii')), (3, 3))
+        tc.assertEqual(check_incomplete(r"(;B[ag\\\])".encode('ascii')), (3, 3))
 
     def test_parser_structure(tc):
         parse_sgf_game = sgf_grammar.parse_sgf_game
@@ -113,47 +113,47 @@ class SgfGrammarTestCase(unittest.TestCase):
             coarse_game = parse_sgf_game(s)
             return len(coarse_game.sequence), len(coarse_game.children)
 
-        tc.assertEqual(shape("(;C[abc]KO[];B[bc])"), (2, 0))
-        tc.assertEqual(shape("initial junk (;C[abc]KO[];B[bc])"), (2, 0))
-        tc.assertEqual(shape("(;C[abc]KO[];B[bc]) final junk"), (2, 0))
-        tc.assertEqual(shape("(;C[abc]KO[];B[bc]) (;B[ag])"), (2, 0))
+        tc.assertEqual(shape(b"(;C[abc]KO[];B[bc])"), (2, 0))
+        tc.assertEqual(shape(b"initial junk (;C[abc]KO[];B[bc])"), (2, 0))
+        tc.assertEqual(shape(b"(;C[abc]KO[];B[bc]) final junk"), (2, 0))
+        tc.assertEqual(shape(b"(;C[abc]KO[];B[bc]) (;B[ag])"), (2, 0))
 
         tc.assertRaisesRegexp(ValueError, "no SGF data found",
-                              parse_sgf_game, r"")
+                              parse_sgf_game, b"")
         tc.assertRaisesRegexp(ValueError, "no SGF data found",
-                              parse_sgf_game, r"junk")
+                              parse_sgf_game, b"junk")
         tc.assertRaisesRegexp(ValueError, "no SGF data found",
-                              parse_sgf_game, r"()")
+                              parse_sgf_game, b"()")
         tc.assertRaisesRegexp(ValueError, "no SGF data found",
-                              parse_sgf_game, r"(B[ag])")
+                              parse_sgf_game, b"(B[ag])")
         tc.assertRaisesRegexp(ValueError, "no SGF data found",
-                              parse_sgf_game, r"B[ag]")
+                              parse_sgf_game, b"B[ag]")
         tc.assertRaisesRegexp(ValueError, "no SGF data found",
-                              parse_sgf_game, r"[ag]")
+                              parse_sgf_game, b"[ag]")
 
-        tc.assertEqual(shape("(;C[abc]AB[ab][bc];B[bc])"), (2, 0))
-        tc.assertEqual(shape("(;C[abc] AB[ab]\n[bc]\t;B[bc])"), (2, 0))
-        tc.assertEqual(shape("(;C[abc]KO[];;B[bc])"), (3, 0))
-        tc.assertEqual(shape("(;)"), (1, 0))
+        tc.assertEqual(shape(b"(;C[abc]AB[ab][bc];B[bc])"), (2, 0))
+        tc.assertEqual(shape(b"(;C[abc] AB[ab]\n[bc]\t;B[bc])"), (2, 0))
+        tc.assertEqual(shape(b"(;C[abc]KO[];;B[bc])"), (3, 0))
+        tc.assertEqual(shape(b"(;)"), (1, 0))
 
         tc.assertRaisesRegexp(ValueError, "property with no values",
-                              parse_sgf_game, r"(;B)")
+                              parse_sgf_game, b"(;B)")
         tc.assertRaisesRegexp(ValueError, "unexpected value",
-                              parse_sgf_game, r"(;[ag])")
+                              parse_sgf_game, b"(;[ag])")
         tc.assertRaisesRegexp(ValueError, "unexpected value",
-                              parse_sgf_game, r"(;[ag][ah])")
+                              parse_sgf_game, b"(;[ag][ah])")
         tc.assertRaisesRegexp(ValueError, "unexpected value",
-                              parse_sgf_game, r"(;[B][ag])")
+                              parse_sgf_game, b"(;[B][ag])")
         tc.assertRaisesRegexp(ValueError, "unexpected end of SGF data",
-                              parse_sgf_game, r"(;B[ag]")
+                              parse_sgf_game, b"(;B[ag]")
         tc.assertRaisesRegexp(ValueError, "unexpected end of SGF data",
-                              parse_sgf_game, r"(;B[ag][)]")
+                              parse_sgf_game, b"(;B[ag][)]")
         tc.assertRaisesRegexp(ValueError, "property with no values",
-                              parse_sgf_game, r"(;B;W[ah])")
+                              parse_sgf_game, b"(;B;W[ah])")
         tc.assertRaisesRegexp(ValueError, "unexpected value",
-                              parse_sgf_game, r"(;B[ag](;[ah]))")
+                              parse_sgf_game, b"(;B[ag](;[ah]))")
         tc.assertRaisesRegexp(ValueError, "property with no values",
-                              parse_sgf_game, r"(;B W[ag])")
+                              parse_sgf_game, b"(;B W[ag])")
 
     def test_parser_tree_structure(tc):
         parse_sgf_game = sgf_grammar.parse_sgf_game
@@ -162,9 +162,9 @@ class SgfGrammarTestCase(unittest.TestCase):
             coarse_game = parse_sgf_game(s)
             return len(coarse_game.sequence), len(coarse_game.children)
 
-        tc.assertEqual(shape("(;C[abc]AB[ab](;B[bc]))"), (1, 1))
-        tc.assertEqual(shape("(;C[abc]AB[ab](;B[bc])))"), (1, 1))
-        tc.assertEqual(shape("(;C[abc]AB[ab](;B[bc])(;B[bd]))"), (1, 2))
+        tc.assertEqual(shape(b"(;C[abc]AB[ab](;B[bc]))"), (1, 1))
+        tc.assertEqual(shape(b"(;C[abc]AB[ab](;B[bc])))"), (1, 1))
+        tc.assertEqual(shape(b"(;C[abc]AB[ab](;B[bc])(;B[bd]))"), (1, 2))
 
         def shapetree(s):
             def _shapetree(coarse_game):
@@ -173,16 +173,16 @@ class SgfGrammarTestCase(unittest.TestCase):
                     [_shapetree(pg) for pg in coarse_game.children])
             return _shapetree(parse_sgf_game(s))
 
-        tc.assertEqual(shapetree("(;C[abc]AB[ab](;B[bc])))"),
+        tc.assertEqual(shapetree(b"(;C[abc]AB[ab](;B[bc])))"),
                        (1, [(1, [])])
                        )
-        tc.assertEqual(shapetree("(;C[abc]AB[ab](;B[bc]))))"),
+        tc.assertEqual(shapetree(b"(;C[abc]AB[ab](;B[bc]))))"),
                        (1, [(1, [])])
                        )
-        tc.assertEqual(shapetree("(;C[abc]AB[ab](;B[bc])(;B[bd])))"),
+        tc.assertEqual(shapetree(b"(;C[abc]AB[ab](;B[bc])(;B[bd])))"),
                        (1, [(1, []), (1, [])])
                        )
-        tc.assertEqual(shapetree("""
+        tc.assertEqual(shapetree(b"""
             (;C[abc]AB[ab];C[];C[]
               (;B[bc])
               (;B[bd];W[ca] (;B[da])(;B[db];W[ea]) )
@@ -194,21 +194,21 @@ class SgfGrammarTestCase(unittest.TestCase):
         )
 
         tc.assertRaisesRegexp(ValueError, "unexpected end of SGF data",
-                              parse_sgf_game, "(;B[ag];W[ah](;B[ai])")
+                              parse_sgf_game, b"(;B[ag];W[ah](;B[ai])")
         tc.assertRaisesRegexp(ValueError, "empty sequence",
-                              parse_sgf_game, "(;B[ag];())")
+                              parse_sgf_game, b"(;B[ag];())")
         tc.assertRaisesRegexp(ValueError, "empty sequence",
-                              parse_sgf_game, "(;B[ag]())")
+                              parse_sgf_game, b"(;B[ag]())")
         tc.assertRaisesRegexp(ValueError, "empty sequence",
-                              parse_sgf_game, "(;B[ag]((;W[ah])(;W[ai]))")
+                              parse_sgf_game, b"(;B[ag]((;W[ah])(;W[ai]))")
         tc.assertRaisesRegexp(ValueError, "unexpected node",
-                              parse_sgf_game, "(;B[ag];W[ah](;B[ai]);W[bd])")
+                              parse_sgf_game, b"(;B[ag];W[ah](;B[ai]);W[bd])")
         tc.assertRaisesRegexp(ValueError, "property value outside a node",
-                              parse_sgf_game, "(;B[ag];(W[ah];B[ai]))")
+                              parse_sgf_game, b"(;B[ag];(W[ah];B[ai]))")
         tc.assertRaisesRegexp(ValueError, "property value outside a node",
-                              parse_sgf_game, "(;B[ag](;W[ah];)B[ai])")
+                              parse_sgf_game, b"(;B[ag](;W[ah];)B[ai])")
         tc.assertRaisesRegexp(ValueError, "property value outside a node",
-                              parse_sgf_game, "(;B[ag](;W[ah])(B[ai]))")
+                              parse_sgf_game, b"(;B[ag](;W[ah])(B[ai]))")
 
     def test_parser_properties(tc):
         parse_sgf_game = sgf_grammar.parse_sgf_game
@@ -217,143 +217,145 @@ class SgfGrammarTestCase(unittest.TestCase):
             coarse_game = parse_sgf_game(s)
             return coarse_game.sequence
 
-        tc.assertEqual(props("(;C[abc]KO[]AB[ai][bh][ee];B[ bc])"),
-                       [{'C': ['abc'], 'KO': [''], 'AB': ['ai', 'bh', 'ee']},
-                        {'B': [' bc']}])
+        tc.assertEqual(props(b"(;C[abc]KO[]AB[ai][bh][ee];B[ bc])"),
+                       [{b'C': [b'abc'], b'KO': [b''], b'AB': [b'ai', b'bh', b'ee']},
+                        {b'B': [b' bc']}])
 
-        tc.assertEqual(props(r"(;C[ab \] \) cd\\])"),
-                       [{'C': [r"ab \] \) cd\\"]}])
+        tc.assertEqual(props(r"(;C[ab \] \) cd\\])".encode('ascii')),
+                       [{b'C': [r"ab \] \) cd\\".encode('ascii')]}])
 
-        tc.assertEqual(props("(;XX[1]YY[2]XX[3]YY[4])"),
-                       [{'XX': ['1', '3'], 'YY' : ['2', '4']}])
+        tc.assertEqual(props(b"(;XX[1]YY[2]XX[3]YY[4])"),
+                       [{b'XX': [b'1', b'3'], b'YY' : [b'2', b'4']}])
 
     def test_parse_sgf_collection(tc):
         parse_sgf_collection = sgf_grammar.parse_sgf_collection
 
         tc.assertRaisesRegexp(ValueError, "no SGF data found",
-                              parse_sgf_collection, r"")
+                              parse_sgf_collection, b"")
         tc.assertRaisesRegexp(ValueError, "no SGF data found",
-                              parse_sgf_collection, r"()")
+                              parse_sgf_collection, b"()")
 
-        games = parse_sgf_collection("(;C[abc]AB[ab];X[];X[](;B[bc]))")
+        games = parse_sgf_collection(b"(;C[abc]AB[ab];X[];X[](;B[bc]))")
         tc.assertEqual(len(games), 1)
         tc.assertEqual(len(games[0].sequence), 3)
 
-        games = parse_sgf_collection("(;X[1];X[2];X[3](;B[bc])) (;Y[1];Y[2])")
+        games = parse_sgf_collection(b"(;X[1];X[2];X[3](;B[bc])) (;Y[1];Y[2])")
         tc.assertEqual(len(games), 2)
         tc.assertEqual(len(games[0].sequence), 3)
         tc.assertEqual(len(games[1].sequence), 2)
 
         games = parse_sgf_collection(
-            "dummy (;X[1];X[2];X[3](;B[bc])) junk (;Y[1];Y[2]) Nonsense")
+            b"dummy (;X[1];X[2];X[3](;B[bc])) junk (;Y[1];Y[2]) Nonsense")
         tc.assertEqual(len(games), 2)
         tc.assertEqual(len(games[0].sequence), 3)
         tc.assertEqual(len(games[1].sequence), 2)
 
         games = parse_sgf_collection(
-            "(( (;X[1];X[2];X[3](;B[bc])) ();) (;Y[1];Y[2]) )(Nonsense")
+            b"(( (;X[1];X[2];X[3](;B[bc])) ();) (;Y[1];Y[2]) )(Nonsense")
         tc.assertEqual(len(games), 2)
         tc.assertEqual(len(games[0].sequence), 3)
         tc.assertEqual(len(games[1].sequence), 2)
 
         with tc.assertRaises(ValueError) as ar:
             parse_sgf_collection(
-                "(( (;X[1];X[2];X[3](;B[bc])) ();) (;Y[1];Y[2]")
+                b"(( (;X[1];X[2];X[3](;B[bc])) ();) (;Y[1];Y[2]")
         tc.assertEqual(str(ar.exception),
                        "error parsing game 1: unexpected end of SGF data")
 
-
     def test_parse_compose(tc):
         pc = sgf_grammar.parse_compose
-        tc.assertEqual(pc("word"), ("word", None))
-        tc.assertEqual(pc("word:"), ("word", ""))
-        tc.assertEqual(pc("word:?"), ("word", "?"))
-        tc.assertEqual(pc("word:123"), ("word", "123"))
-        tc.assertEqual(pc("word:123:456"), ("word", "123:456"))
-        tc.assertEqual(pc(":123"), ("", "123"))
-        tc.assertEqual(pc(r"word\:more"), (r"word\:more", None))
-        tc.assertEqual(pc(r"word\:more:?"), (r"word\:more", "?"))
-        tc.assertEqual(pc(r"word\\:more:?"), ("word\\\\", "more:?"))
-        tc.assertEqual(pc(r"word\\\:more:?"), (r"word\\\:more", "?"))
-        tc.assertEqual(pc("word\\\nmore:123"), ("word\\\nmore", "123"))
+        tc.assertEqual(pc(b"word"), (b"word", None))
+        tc.assertEqual(pc(b"word:"), (b"word", b""))
+        tc.assertEqual(pc(b"word:?"), (b"word", b"?"))
+        tc.assertEqual(pc(b"word:123"), (b"word", b"123"))
+        tc.assertEqual(pc(b"word:123:456"), (b"word", b"123:456"))
+        tc.assertEqual(pc(b":123"), (b"", b"123"))
+        tc.assertEqual(pc(r"word\:more".encode('ascii')), (r"word\:more".encode('ascii'), None))
+        tc.assertEqual(pc(r"word\:more:?".encode('ascii')), (r"word\:more".encode('ascii'), b"?"))
+        tc.assertEqual(pc(r"word\\:more:?".encode('ascii')), (b"word\\\\", b"more:?"))
+        tc.assertEqual(pc(r"word\\\:more:?".encode('ascii')),
+                       (r"word\\\:more".encode('ascii'), b"?"))
+        tc.assertEqual(pc(b"word\\\nmore:123"), (b"word\\\nmore", b"123"))
 
     def test_text_value(tc):
         text_value = sgf_grammar.text_value
-        tc.assertEqual(text_value("abc "), "abc ")
-        tc.assertEqual(text_value("ab c"), "ab c")
-        tc.assertEqual(text_value("ab\tc"), "ab c")
-        tc.assertEqual(text_value("ab \tc"), "ab  c")
-        tc.assertEqual(text_value("ab\nc"), "ab\nc")
-        tc.assertEqual(text_value("ab\\\nc"), "abc")
-        tc.assertEqual(text_value("ab\\\\\nc"), "ab\\\nc")
-        tc.assertEqual(text_value("ab\xa0c"), "ab\xa0c")
+        tc.assertEqual(text_value(b"abc "), b"abc ")
+        tc.assertEqual(text_value(b"ab c"), b"ab c")
+        tc.assertEqual(text_value(b"ab\tc"), b"ab c")
+        tc.assertEqual(text_value(b"ab \tc"), b"ab  c")
+        tc.assertEqual(text_value(b"ab\nc"), b"ab\nc")
+        tc.assertEqual(text_value(b"ab\\\nc"), b"abc")
+        tc.assertEqual(text_value(b"ab\\\\\nc"), b"ab\\\nc")
+        tc.assertEqual(text_value(b"ab\xa0c"), b"ab\xa0c")
 
-        tc.assertEqual(text_value("ab\rc"), "ab\nc")
-        tc.assertEqual(text_value("ab\r\nc"), "ab\nc")
-        tc.assertEqual(text_value("ab\n\rc"), "ab\nc")
-        tc.assertEqual(text_value("ab\r\n\r\nc"), "ab\n\nc")
-        tc.assertEqual(text_value("ab\r\n\r\n\rc"), "ab\n\n\nc")
-        tc.assertEqual(text_value("ab\\\r\nc"), "abc")
-        tc.assertEqual(text_value("ab\\\n\nc"), "ab\nc")
+        tc.assertEqual(text_value(b"ab\rc"), b"ab\nc")
+        tc.assertEqual(text_value(b"ab\r\nc"), b"ab\nc")
+        tc.assertEqual(text_value(b"ab\n\rc"), b"ab\nc")
+        tc.assertEqual(text_value(b"ab\r\n\r\nc"), b"ab\n\nc")
+        tc.assertEqual(text_value(b"ab\r\n\r\n\rc"), b"ab\n\n\nc")
+        tc.assertEqual(text_value(b"ab\\\r\nc"), b"abc")
+        tc.assertEqual(text_value(b"ab\\\n\nc"), b"ab\nc")
 
-        tc.assertEqual(text_value("ab\\\tc"), "ab c")
+        tc.assertEqual(text_value(b"ab\\\tc"), b"ab c")
 
         # These can't actually appear as SGF PropValues; anything sane will do
-        tc.assertEqual(text_value("abc\\"), "abc")
-        tc.assertEqual(text_value("abc]"), "abc]")
+        tc.assertEqual(text_value(b"abc\\"), b"abc")
+        tc.assertEqual(text_value(b"abc]"), b"abc]")
 
     def test_simpletext_value(tc):
         simpletext_value = sgf_grammar.simpletext_value
-        tc.assertEqual(simpletext_value("abc "), "abc ")
-        tc.assertEqual(simpletext_value("ab c"), "ab c")
-        tc.assertEqual(simpletext_value("ab\tc"), "ab c")
-        tc.assertEqual(simpletext_value("ab \tc"), "ab  c")
-        tc.assertEqual(simpletext_value("ab\nc"), "ab c")
-        tc.assertEqual(simpletext_value("ab\\\nc"), "abc")
-        tc.assertEqual(simpletext_value("ab\\\\\nc"), "ab\\ c")
-        tc.assertEqual(simpletext_value("ab\xa0c"), "ab\xa0c")
+        tc.assertEqual(simpletext_value(b"abc "), b"abc ")
+        tc.assertEqual(simpletext_value(b"ab c"), b"ab c")
+        tc.assertEqual(simpletext_value(b"ab\tc"), b"ab c")
+        tc.assertEqual(simpletext_value(b"ab \tc"), b"ab  c")
+        tc.assertEqual(simpletext_value(b"ab\nc"), b"ab c")
+        tc.assertEqual(simpletext_value(b"ab\\\nc"), b"abc")
+        tc.assertEqual(simpletext_value(b"ab\\\\\nc"), b"ab\\ c")
+        tc.assertEqual(simpletext_value(b"ab\xa0c"), b"ab\xa0c")
 
-        tc.assertEqual(simpletext_value("ab\rc"), "ab c")
-        tc.assertEqual(simpletext_value("ab\r\nc"), "ab c")
-        tc.assertEqual(simpletext_value("ab\n\rc"), "ab c")
-        tc.assertEqual(simpletext_value("ab\r\n\r\nc"), "ab  c")
-        tc.assertEqual(simpletext_value("ab\r\n\r\n\rc"), "ab   c")
-        tc.assertEqual(simpletext_value("ab\\\r\nc"), "abc")
-        tc.assertEqual(simpletext_value("ab\\\n\nc"), "ab c")
+        tc.assertEqual(simpletext_value(b"ab\rc"), b"ab c")
+        tc.assertEqual(simpletext_value(b"ab\r\nc"), b"ab c")
+        tc.assertEqual(simpletext_value(b"ab\n\rc"), b"ab c")
+        tc.assertEqual(simpletext_value(b"ab\r\n\r\nc"), b"ab  c")
+        tc.assertEqual(simpletext_value(b"ab\r\n\r\n\rc"), b"ab   c")
+        tc.assertEqual(simpletext_value(b"ab\\\r\nc"), b"abc")
+        tc.assertEqual(simpletext_value(b"ab\\\n\nc"), b"ab c")
 
-        tc.assertEqual(simpletext_value("ab\\\tc"), "ab c")
+        tc.assertEqual(simpletext_value(b"ab\\\tc"), b"ab c")
 
         # These can't actually appear as SGF PropValues; anything sane will do
-        tc.assertEqual(simpletext_value("abc\\"), "abc")
-        tc.assertEqual(simpletext_value("abc]"), "abc]")
+        tc.assertEqual(simpletext_value(b"abc\\"), b"abc")
+        tc.assertEqual(simpletext_value(b"abc]"), b"abc]")
 
     def test_escape_text(tc):
-        tc.assertEqual(sgf_grammar.escape_text("abc"), "abc")
-        tc.assertEqual(sgf_grammar.escape_text(r"a\bc"), r"a\\bc")
-        tc.assertEqual(sgf_grammar.escape_text(r"ab[c]"), r"ab[c\]")
-        tc.assertEqual(sgf_grammar.escape_text(r"a\]bc"), r"a\\\]bc")
+        tc.assertEqual(sgf_grammar.escape_text(b"abc"), b"abc")
+        tc.assertEqual(sgf_grammar.escape_text(r"a\bc".encode('ascii')), r"a\\bc".encode('ascii'))
+        tc.assertEqual(sgf_grammar.escape_text(r"ab[c]".encode('ascii')),
+                       r"ab[c\]".encode('ascii'))
+        tc.assertEqual(sgf_grammar.escape_text(r"a\]bc".encode('ascii')),
+                       r"a\\\]bc".encode('ascii'))
 
     def test_text_roundtrip(tc):
         def roundtrip(s):
             return sgf_grammar.text_value(sgf_grammar.escape_text(s))
-        tc.assertEqual(roundtrip(r"abc"), r"abc")
-        tc.assertEqual(roundtrip(r"a\bc"), r"a\bc")
-        tc.assertEqual(roundtrip("abc\\"), "abc\\")
-        tc.assertEqual(roundtrip("ab]c"), "ab]c")
-        tc.assertEqual(roundtrip("abc]"), "abc]")
-        tc.assertEqual(roundtrip(r"abc\]"), r"abc\]")
-        tc.assertEqual(roundtrip("ab\nc"), "ab\nc")
-        tc.assertEqual(roundtrip("ab\n  c"), "ab\n  c")
+        tc.assertEqual(roundtrip(b"abc"), b"abc")
+        tc.assertEqual(roundtrip(r"a\bc".encode('ascii')), r"a\bc".encode('ascii'))
+        tc.assertEqual(roundtrip(b"abc\\"), b"abc\\")
+        tc.assertEqual(roundtrip(b"ab]c"), b"ab]c")
+        tc.assertEqual(roundtrip(b"abc]"), b"abc]")
+        tc.assertEqual(roundtrip(r"abc\]".encode('ascii')), r"abc\]".encode('ascii'))
+        tc.assertEqual(roundtrip(b"ab\nc"), b"ab\nc")
+        tc.assertEqual(roundtrip(b"ab\n  c"), b"ab\n  c")
 
-        tc.assertEqual(roundtrip("ab\tc"), "ab c")
-        tc.assertEqual(roundtrip("ab\r\nc\n"), "ab\nc\n")
+        tc.assertEqual(roundtrip(b"ab\tc"), b"ab c")
+        tc.assertEqual(roundtrip(b"ab\r\nc\n"), b"ab\nc\n")
 
     def test_serialise_game_tree(tc):
-        serialised = ("(;AB[aa][ab][ac]C[comment \xa3];W[ab];C[];C[]"
-                      "(;B[bc])(;B[bd];W[ca](;B[da])(;B[db];\n"
-                      "W[ea])))\n")
+        serialised = (b"(;AB[aa][ab][ac]C[comment \xa3];W[ab];C[];C[]"
+                      b"(;B[bc])(;B[bd];W[ca](;B[da])(;B[db];\n"
+                      b"W[ea])))\n")
         coarse_game = sgf_grammar.parse_sgf_game(serialised)
         tc.assertEqual(sgf_grammar.serialise_game_tree(coarse_game), serialised)
         tc.assertEqual(sgf_grammar.serialise_game_tree(coarse_game, wrap=None),
-                       serialised.replace("\n", "")+"\n")
+                       serialised.replace(b"\n", b"")+b"\n")
 

--- a/tests/gosgf/sgf_properties_test.py
+++ b/tests/gosgf/sgf_properties_test.py
@@ -11,7 +11,7 @@ class SgfPropertiesTestCase(unittest.TestCase):
         def interpret(s, encoding):
             context = sgf_properties._Context(19, encoding)
             return sgf_properties.interpret_simpletext(s, context)
-        self.assertEqual(interpret("a\nb\\\\c", "utf-8"), "a b\\c")
+        self.assertEqual(interpret(b"a\nb\\\\c", "utf-8"), b"a b\\c")
         u = u"test \N{POUND SIGN}"
         self.assertEqual(interpret(u.encode("utf-8"), "UTF-8"),
                          u.encode("utf-8"))
@@ -25,7 +25,7 @@ class SgfPropertiesTestCase(unittest.TestCase):
         def serialise(s, encoding):
             context = sgf_properties._Context(19, encoding)
             return sgf_properties.serialise_simpletext(s, context)
-        self.assertEqual(serialise("ab\\c", "utf-8"), "ab\\\\c")
+        self.assertEqual(serialise(b"ab\\c", "utf-8"), b"ab\\\\c")
         u = u"test \N{POUND SIGN}"
         self.assertEqual(serialise(u.encode("utf-8"), "UTF-8"),
                          u.encode("utf-8"))
@@ -38,7 +38,7 @@ class SgfPropertiesTestCase(unittest.TestCase):
         def interpret(s, encoding):
             context = sgf_properties._Context(19, encoding)
             return sgf_properties.interpret_text(s, context)
-        self.assertEqual(interpret("a\nb\\\\c", "utf-8"), "a\nb\\c")
+        self.assertEqual(interpret(b"a\nb\\\\c", "utf-8"), b"a\nb\\c")
         u = u"test \N{POUND SIGN}"
         self.assertEqual(interpret(u.encode("utf-8"), "UTF-8"),
                          u.encode("utf-8"))
@@ -52,7 +52,7 @@ class SgfPropertiesTestCase(unittest.TestCase):
         def serialise(s, encoding):
             context = sgf_properties._Context(19, encoding)
             return sgf_properties.serialise_text(s, context)
-        self.assertEqual(serialise("ab\\c", "utf-8"), "ab\\\\c")
+        self.assertEqual(serialise(b"ab\\c", "utf-8"), b"ab\\\\c")
         u = u"test \N{POUND SIGN}"
         self.assertEqual(serialise(u.encode("utf-8"), "UTF-8"),
                          u.encode("utf-8"))
@@ -91,20 +91,20 @@ class SgfPropertiesTestCase(unittest.TestCase):
 
     def test_serialise_real(self):
         serialise_real = sgf_properties.serialise_real
-        self.assertEqual(serialise_real(1), "1")
-        self.assertEqual(serialise_real(-1), "-1")
-        self.assertEqual(serialise_real(1.0), "1")
-        self.assertEqual(serialise_real(-1.0), "-1")
-        self.assertEqual(serialise_real(1.5), "1.5")
-        self.assertEqual(serialise_real(-1.5), "-1.5")
-        self.assertEqual(serialise_real(0.001), "0.001")
-        self.assertEqual(serialise_real(0.0001), "0.0001")
-        self.assertEqual(serialise_real(0.00001), "0")
-        self.assertEqual(serialise_real(1e15), "1000000000000000")
-        self.assertEqual(serialise_real(1e16), "10000000000000000")
-        self.assertEqual(serialise_real(1e17), "100000000000000000")
-        self.assertEqual(serialise_real(1e18), "1000000000000000000")
-        self.assertEqual(serialise_real(-1e18), "-1000000000000000000")
+        self.assertEqual(serialise_real(1), b"1")
+        self.assertEqual(serialise_real(-1), b"-1")
+        self.assertEqual(serialise_real(1.0), b"1")
+        self.assertEqual(serialise_real(-1.0), b"-1")
+        self.assertEqual(serialise_real(1.5), b"1.5")
+        self.assertEqual(serialise_real(-1.5), b"-1.5")
+        self.assertEqual(serialise_real(0.001), b"0.001")
+        self.assertEqual(serialise_real(0.0001), b"0.0001")
+        self.assertEqual(serialise_real(0.00001), b"0")
+        self.assertEqual(serialise_real(1e15), b"1000000000000000")
+        self.assertEqual(serialise_real(1e16), b"10000000000000000")
+        self.assertEqual(serialise_real(1e17), b"100000000000000000")
+        self.assertEqual(serialise_real(1e18), b"1000000000000000000")
+        self.assertEqual(serialise_real(-1e18), b"-1000000000000000000")
         # 1e400 is inf
         self.assertRaises(ValueError, serialise_real, 1e400)
         # Python 2.5 returns 0
@@ -115,24 +115,24 @@ class SgfPropertiesTestCase(unittest.TestCase):
         def interpret_move(s, size):
             context = sgf_properties._Context(size, "UTF-8")
             return sgf_properties.interpret_move(s, context)
-        self.assertEqual(interpret_move("aa", 19), (18, 0))
-        self.assertEqual(interpret_move("ai", 19), (10, 0))
-        self.assertEqual(interpret_move("ba",  9), (8, 1))
-        self.assertEqual(interpret_move("tt", 21), (1, 19))
-        self.assertIs(interpret_move("tt", 19), None)
-        self.assertIs(interpret_move("", 19), None)
-        self.assertIs(interpret_move("", 21), None)
-        self.assertRaises(ValueError, interpret_move, "Aa", 19)
-        self.assertRaises(ValueError, interpret_move, "aA", 19)
-        self.assertRaises(ValueError, interpret_move, "aaa", 19)
-        self.assertRaises(ValueError, interpret_move, "a", 19)
-        self.assertRaises(ValueError, interpret_move, "au", 19)
-        self.assertRaises(ValueError, interpret_move, "ua", 19)
-        self.assertRaises(ValueError, interpret_move, "a`", 19)
-        self.assertRaises(ValueError, interpret_move, "`a", 19)
-        self.assertRaises(ValueError, interpret_move, "11", 19)
-        self.assertRaises(ValueError, interpret_move, " aa", 19)
-        self.assertRaises(ValueError, interpret_move, "aa\x00", 19)
+        self.assertEqual(interpret_move(b"aa", 19), (18, 0))
+        self.assertEqual(interpret_move(b"ai", 19), (10, 0))
+        self.assertEqual(interpret_move(b"ba",  9), (8, 1))
+        self.assertEqual(interpret_move(b"tt", 21), (1, 19))
+        self.assertIs(interpret_move(b"tt", 19), None)
+        self.assertIs(interpret_move(b"", 19), None)
+        self.assertIs(interpret_move(b"", 21), None)
+        self.assertRaises(ValueError, interpret_move, b"Aa", 19)
+        self.assertRaises(ValueError, interpret_move, b"aA", 19)
+        self.assertRaises(ValueError, interpret_move, b"aaa", 19)
+        self.assertRaises(ValueError, interpret_move, b"a", 19)
+        self.assertRaises(ValueError, interpret_move, b"au", 19)
+        self.assertRaises(ValueError, interpret_move, b"ua", 19)
+        self.assertRaises(ValueError, interpret_move, b"a`", 19)
+        self.assertRaises(ValueError, interpret_move, b"`a", 19)
+        self.assertRaises(ValueError, interpret_move, b"11", 19)
+        self.assertRaises(ValueError, interpret_move, b" aa", 19)
+        self.assertRaises(ValueError, interpret_move, b"aa\x00", 19)
         self.assertRaises(TypeError, interpret_move, None, 19)
         #self.assertRaises(TypeError, interpret_move, ('a', 'a'), 19)
 
@@ -140,13 +140,13 @@ class SgfPropertiesTestCase(unittest.TestCase):
         def serialise_move(s, size):
             context = sgf_properties._Context(size, "UTF-8")
             return sgf_properties.serialise_move(s, context)
-        self.assertEqual(serialise_move((18, 0), 19), "aa")
-        self.assertEqual(serialise_move((10, 0), 19), "ai")
-        self.assertEqual(serialise_move((8, 1), 19), "bk")
-        self.assertEqual(serialise_move((8, 1), 9), "ba")
-        self.assertEqual(serialise_move((1, 19), 21), "tt")
-        self.assertEqual(serialise_move(None, 19), "tt")
-        self.assertEqual(serialise_move(None, 20), "")
+        self.assertEqual(serialise_move((18, 0), 19), b"aa")
+        self.assertEqual(serialise_move((10, 0), 19), b"ai")
+        self.assertEqual(serialise_move((8, 1), 19), b"bk")
+        self.assertEqual(serialise_move((8, 1), 9), b"ba")
+        self.assertEqual(serialise_move((1, 19), 21), b"tt")
+        self.assertEqual(serialise_move(None, 19), b"tt")
+        self.assertEqual(serialise_move(None, 20), b"")
         self.assertRaises(ValueError, serialise_move, (3, 3), 0)
         self.assertRaises(ValueError, serialise_move, (3, 3), 27)
         self.assertRaises(ValueError, serialise_move, (9, 0), 9)
@@ -159,24 +159,24 @@ class SgfPropertiesTestCase(unittest.TestCase):
         def interpret_point(s, size):
             context = sgf_properties._Context(size, "UTF-8")
             return sgf_properties.interpret_point(s, context)
-        self.assertEqual(interpret_point("aa", 19), (18, 0))
-        self.assertEqual(interpret_point("ai", 19), (10, 0))
-        self.assertEqual(interpret_point("ba",  9), (8, 1))
-        self.assertEqual(interpret_point("tt", 21), (1, 19))
-        self.assertRaises(ValueError, interpret_point, "tt", 19)
-        self.assertRaises(ValueError, interpret_point, "", 19)
-        self.assertRaises(ValueError, interpret_point, "", 21)
-        self.assertRaises(ValueError, interpret_point, "Aa", 19)
-        self.assertRaises(ValueError, interpret_point, "aA", 19)
-        self.assertRaises(ValueError, interpret_point, "aaa", 19)
-        self.assertRaises(ValueError, interpret_point, "a", 19)
-        self.assertRaises(ValueError, interpret_point, "au", 19)
-        self.assertRaises(ValueError, interpret_point, "ua", 19)
-        self.assertRaises(ValueError, interpret_point, "a`", 19)
-        self.assertRaises(ValueError, interpret_point, "`a", 19)
-        self.assertRaises(ValueError, interpret_point, "11", 19)
-        self.assertRaises(ValueError, interpret_point, " aa", 19)
-        self.assertRaises(ValueError, interpret_point, "aa\x00", 19)
+        self.assertEqual(interpret_point(b"aa", 19), (18, 0))
+        self.assertEqual(interpret_point(b"ai", 19), (10, 0))
+        self.assertEqual(interpret_point(b"ba",  9), (8, 1))
+        self.assertEqual(interpret_point(b"tt", 21), (1, 19))
+        self.assertRaises(ValueError, interpret_point, b"tt", 19)
+        self.assertRaises(ValueError, interpret_point, b"", 19)
+        self.assertRaises(ValueError, interpret_point, b"", 21)
+        self.assertRaises(ValueError, interpret_point, b"Aa", 19)
+        self.assertRaises(ValueError, interpret_point, b"aA", 19)
+        self.assertRaises(ValueError, interpret_point, b"aaa", 19)
+        self.assertRaises(ValueError, interpret_point, b"a", 19)
+        self.assertRaises(ValueError, interpret_point, b"au", 19)
+        self.assertRaises(ValueError, interpret_point, b"ua", 19)
+        self.assertRaises(ValueError, interpret_point, b"a`", 19)
+        self.assertRaises(ValueError, interpret_point, b"`a", 19)
+        self.assertRaises(ValueError, interpret_point, b"11", 19)
+        self.assertRaises(ValueError, interpret_point, b" aa", 19)
+        self.assertRaises(ValueError, interpret_point, b"aa\x00", 19)
         self.assertRaises(TypeError, interpret_point, None, 19)
         #self.assertRaises(TypeError, interpret_point, ('a', 'a'), 19)
 
@@ -184,11 +184,11 @@ class SgfPropertiesTestCase(unittest.TestCase):
         def serialise_point(s, size):
             context = sgf_properties._Context(size, "UTF-8")
             return sgf_properties.serialise_point(s, context)
-        self.assertEqual(serialise_point((18, 0), 19), "aa")
-        self.assertEqual(serialise_point((10, 0), 19), "ai")
-        self.assertEqual(serialise_point((8, 1), 19), "bk")
-        self.assertEqual(serialise_point((8, 1), 9), "ba")
-        self.assertEqual(serialise_point((1, 19), 21), "tt")
+        self.assertEqual(serialise_point((18, 0), 19), b"aa")
+        self.assertEqual(serialise_point((10, 0), 19), b"ai")
+        self.assertEqual(serialise_point((8, 1), 19), b"bk")
+        self.assertEqual(serialise_point((8, 1), 9), b"ba")
+        self.assertEqual(serialise_point((1, 19), 21), b"tt")
         self.assertRaises(ValueError, serialise_point, None, 19)
         self.assertRaises(ValueError, serialise_point, None, 20)
         self.assertRaises(ValueError, serialise_point, (3, 3), 0)
@@ -206,56 +206,56 @@ class SgfPropertiesTestCase(unittest.TestCase):
             return sgf_properties.interpret_point_list(l, context)
         self.assertEqual(ipl([], 19),
                          set())
-        self.assertEqual(ipl(["aa"], 19),
+        self.assertEqual(ipl([b"aa"], 19),
                          set([(18, 0)]))
-        self.assertEqual(ipl(["aa", "ai"], 19),
+        self.assertEqual(ipl([b"aa", b"ai"], 19),
                          set([(18, 0), (10, 0)]))
-        self.assertEqual(ipl(["ab:bc"], 19),
+        self.assertEqual(ipl([b"ab:bc"], 19),
                          set([(16, 0), (16, 1), (17, 0), (17, 1)]))
-        self.assertEqual(ipl(["ab:bc", "aa"], 19),
+        self.assertEqual(ipl([b"ab:bc", b"aa"], 19),
                          set([(18, 0), (16, 0), (16, 1), (17, 0), (17, 1)]))
         # overlap is forbidden by the spec, but we accept it
-        self.assertEqual(ipl(["aa", "aa"], 19),
+        self.assertEqual(ipl([b"aa", b"aa"], 19),
                          set([(18, 0)]))
-        self.assertEqual(ipl(["ab:bc", "bb:bc"], 19),
+        self.assertEqual(ipl([b"ab:bc", b"bb:bc"], 19),
                          set([(16, 0), (16, 1), (17, 0), (17, 1)]))
         # 1x1 rectangles are forbidden by the spec, but we accept them
-        self.assertEqual(ipl(["aa", "bb:bb"], 19),
+        self.assertEqual(ipl([b"aa", b"bb:bb"], 19),
                          set([(18, 0), (17, 1)]))
         # 'backwards' rectangles are forbidden by the spec, and we reject them
-        self.assertRaises(ValueError, ipl, ["ab:aa"], 19)
-        self.assertRaises(ValueError, ipl, ["ba:aa"], 19)
-        self.assertRaises(ValueError, ipl, ["bb:aa"], 19)
+        self.assertRaises(ValueError, ipl, [b"ab:aa"], 19)
+        self.assertRaises(ValueError, ipl, [b"ba:aa"], 19)
+        self.assertRaises(ValueError, ipl, [b"bb:aa"], 19)
 
-        self.assertRaises(ValueError, ipl, ["aa", "tt"], 19)
-        self.assertRaises(ValueError, ipl, ["aa", ""], 19)
-        self.assertRaises(ValueError, ipl, ["aa:", "aa"], 19)
-        self.assertRaises(ValueError, ipl, ["aa:tt", "aa"], 19)
-        self.assertRaises(ValueError, ipl, ["tt:aa", "aa"], 19)
+        self.assertRaises(ValueError, ipl, [b"aa", b"tt"], 19)
+        self.assertRaises(ValueError, ipl, [b"aa", b""], 19)
+        self.assertRaises(ValueError, ipl, [b"aa:", b"aa"], 19)
+        self.assertRaises(ValueError, ipl, [b"aa:tt", b"aa"], 19)
+        self.assertRaises(ValueError, ipl, [b"tt:aa", b"aa"], 19)
 
     def test_compressed_point_list_spec_example(self):
         # Checks the examples at http://www.red-bean.com/sgf/DD_VW.html
         def sgf_point(move, size):
             row, col = move
             row = size - row - 1
-            col_s = "abcdefghijklmnopqrstuvwxy"[col]
-            row_s = "abcdefghijklmnopqrstuvwxy"[row]
+            col_s = "abcdefghijklmnopqrstuvwxy"[col].encode('ascii')
+            row_s = "abcdefghijklmnopqrstuvwxy"[row].encode('ascii')
             return col_s + row_s
 
         def ipl(l, size):
             context = sgf_properties._Context(size, "UTF-8")
             return sgf_properties.interpret_point_list(l, context)
         self.assertEqual(
-            set(sgf_point(move, 9) for move in ipl(["ac:ic"], 9)),
-            set(["ac", "bc", "cc", "dc", "ec", "fc", "gc", "hc", "ic"]))
+            set(sgf_point(move, 9) for move in ipl([b"ac:ic"], 9)),
+            set([b"ac", b"bc", b"cc", b"dc", b"ec", b"fc", b"gc", b"hc", b"ic"]))
         self.assertEqual(
-            set(sgf_point(move, 9) for move in ipl(["ae:ie"], 9)),
-            set(["ae", "be", "ce", "de", "ee", "fe", "ge", "he", "ie"]))
+            set(sgf_point(move, 9) for move in ipl([b"ae:ie"], 9)),
+            set([b"ae", b"be", b"ce", b"de", b"ee", b"fe", b"ge", b"he", b"ie"]))
         self.assertEqual(
-            set(sgf_point(move, 9) for move in ipl(["aa:bi", "ca:ce"], 9)),
-            set(["aa", "ab", "ac", "ad", "ae", "af", "ag", "ah", "ai",
-                 "bi", "bh", "bg", "bf", "be", "bd", "bc", "bb", "ba",
-                 "ca", "cb", "cc", "cd", "ce"]))
+            set(sgf_point(move, 9) for move in ipl([b"aa:bi", b"ca:ce"], 9)),
+            set([b"aa", b"ab", b"ac", b"ad", b"ae", b"af", b"ag", b"ah", b"ai",
+                 b"bi", b"bh", b"bg", b"bf", b"be", b"bd", b"bc", b"bb", b"ba",
+                 b"ca", b"cb", b"cc", b"cd", b"ce"]))
 
     def test_serialise_point_list(self):
         def ipl(l, size):
@@ -265,8 +265,8 @@ class SgfPropertiesTestCase(unittest.TestCase):
             context = sgf_properties._Context(size, "UTF-8")
             return sgf_properties.serialise_point_list(l, context)
 
-        self.assertEqual(spl([(18, 0), (17, 1)], 19), ['aa', 'bb'])
-        self.assertEqual(spl([(17, 1), (18, 0)], 19), ['aa', 'bb'])
+        self.assertEqual(spl([(18, 0), (17, 1)], 19), [b'aa', b'bb'])
+        self.assertEqual(spl([(17, 1), (18, 0)], 19), [b'aa', b'bb'])
         self.assertEqual(spl([], 9), [])
         self.assertEqual(ipl(spl([(1,2), (3,4), (4,5)], 19), 19),
                          set([(1,2), (3,4), (4,5)]))
@@ -280,9 +280,9 @@ class SgfPropertiesTestCase(unittest.TestCase):
             context = sgf_properties._Context(19, "UTF-8")
             return sgf_properties.interpret_AP(arg, context)
 
-        self.assertEqual(serialise(("foo:bar", "2\n3")), "foo\\:bar:2\n3")
-        self.assertEqual(interpret("foo\\:bar:2 3"), ("foo:bar", "2 3"))
-        self.assertEqual(interpret("foo bar"), ("foo bar", ""))
+        self.assertEqual(serialise((b"foo:bar", b"2\n3")), b"foo\\:bar:2\n3")
+        self.assertEqual(interpret(b"foo\\:bar:2 3"), (b"foo:bar", b"2 3"))
+        self.assertEqual(interpret(b"foo bar"), (b"foo bar", b""))
 
     def test_ARLN(self):
         def serialise(arg, size):
@@ -295,11 +295,11 @@ class SgfPropertiesTestCase(unittest.TestCase):
         self.assertEqual(serialise([], 19), [])
         self.assertEqual(interpret([], 19), [])
         self.assertEqual(serialise([((7, 0), (5, 2)), ((4, 3), (2, 5))], 9),
-                         ['ab:cd', 'de:fg'])
-        self.assertEqual(interpret(['ab:cd', 'de:fg'], 9),
+                         [b'ab:cd', b'de:fg'])
+        self.assertEqual(interpret([b'ab:cd', b'de:fg'], 9),
                          [((7, 0), (5, 2)), ((4, 3), (2, 5))])
         self.assertRaises(ValueError, serialise, [((7, 0), None)], 9)
-        self.assertRaises(ValueError, interpret, ['ab:tt', 'de:fg'], 9)
+        self.assertRaises(ValueError, interpret, [b'ab:tt', b'de:fg'], 9)
 
     def test_FG(self):
         def serialise(arg):
@@ -308,10 +308,10 @@ class SgfPropertiesTestCase(unittest.TestCase):
         def interpret(arg):
             context = sgf_properties._Context(19, "UTF-8")
             return sgf_properties.interpret_FG(arg, context)
-        self.assertEqual(serialise(None), "")
-        self.assertEqual(interpret(""), None)
-        self.assertEqual(serialise((515, "th]is")), "515:th\\]is")
-        self.assertEqual(interpret("515:th\\]is"), (515, "th]is"))
+        self.assertEqual(serialise(None), b"")
+        self.assertEqual(interpret(b""), None)
+        self.assertEqual(serialise((515, b"th]is")), b"515:th\\]is")
+        self.assertEqual(interpret(b"515:th\\]is"), (515, b"th]is"))
 
     def test_LB(self):
         def serialise(arg, size):
@@ -323,57 +323,57 @@ class SgfPropertiesTestCase(unittest.TestCase):
         self.assertEqual(serialise([], 19), [])
         self.assertEqual(interpret([], 19), [])
         self.assertEqual(
-            serialise([((6, 0), "lbl"), ((6, 1), "lb]l2")], 9),
-            ["ac:lbl", "bc:lb\\]l2"])
+            serialise([((6, 0), b"lbl"), ((6, 1), b"lb]l2")], 9),
+            [b"ac:lbl", b"bc:lb\\]l2"])
         self.assertEqual(
-            interpret(["ac:lbl", "bc:lb\\]l2"], 9),
-            [((6, 0), "lbl"), ((6, 1), "lb]l2")])
-        self.assertRaises(ValueError, serialise, [(None, "lbl")], 9)
-        self.assertRaises(ValueError, interpret, [':lbl', 'de:lbl2'], 9)
+            interpret([b"ac:lbl", b"bc:lb\\]l2"], 9),
+            [((6, 0), b"lbl"), ((6, 1), b"lb]l2")])
+        self.assertRaises(ValueError, serialise, [(None, b"lbl")], 9)
+        self.assertRaises(ValueError, interpret, [b':lbl', b'de:lbl2'], 9)
 
     def test_presenter_interpret(self):
         p9 = sgf_properties.Presenter(9, "UTF-8")
         p19 = sgf_properties.Presenter(19, "UTF-8")
-        self.assertEqual(p9.interpret('KO', [""]), True)
-        self.assertEqual(p9.interpret('SZ', ["9"]), 9)
+        self.assertEqual(p9.interpret(b'KO', [b""]), True)
+        self.assertEqual(p9.interpret(b'SZ', [b"9"]), 9)
         self.assertRaisesRegexp(ValueError, "multiple values",
-                                p9.interpret, 'SZ', ["9", "blah"])
-        self.assertEqual(p9.interpret('CR', ["ab", "cd"]), set([(5, 2), (7, 0)]))
-        self.assertRaises(ValueError, p9.interpret, 'SZ', [])
-        self.assertRaises(ValueError, p9.interpret, 'CR', [])
-        self.assertEqual(p9.interpret('DD', [""]), set())
+                                p9.interpret, b'SZ', [b"9", b"blah"])
+        self.assertEqual(p9.interpret(b'CR', [b"ab", b"cd"]), set([(5, 2), (7, 0)]))
+        self.assertRaises(ValueError, p9.interpret, b'SZ', [])
+        self.assertRaises(ValueError, p9.interpret, b'CR', [])
+        self.assertEqual(p9.interpret(b'DD', [b""]), set())
         # all lists are treated like elists
-        self.assertEqual(p9.interpret('CR', [""]), set())
+        self.assertEqual(p9.interpret(b'CR', [b""]), set())
 
     def test_presenter_serialise(self):
         p9 = sgf_properties.Presenter(9, "UTF-8")
         p19 = sgf_properties.Presenter(19, "UTF-8")
 
-        self.assertEqual(p9.serialise('KO', True), [""])
-        self.assertEqual(p9.serialise('SZ', 9), ["9"])
-        self.assertEqual(p9.serialise('KM', 3.5), ["3.5"])
-        self.assertEqual(p9.serialise('C', "foo\\:b]ar\n"), ["foo\\\\:b\\]ar\n"])
-        self.assertEqual(p19.serialise('B', (1, 2)), ["cr"])
-        self.assertEqual(p9.serialise('B', None), ["tt"])
-        self.assertEqual(p19.serialise('AW', set([(17, 1), (18, 0)])),["aa", "bb"])
-        self.assertEqual(p9.serialise('DD', [(1, 2), (3, 4)]), ["ch", "ef"])
-        self.assertEqual(p9.serialise('DD', []), [""])
-        self.assertRaisesRegexp(ValueError, "empty list", p9.serialise, 'CR', [])
-        self.assertEqual(p9.serialise('AP', ("na:me", "2.3")), ["na\\:me:2.3"])
-        self.assertEqual(p9.serialise('FG', (515, "th]is")), ["515:th\\]is"])
-        self.assertEqual(p9.serialise('XX', "foo\\bar"), ["foo\\\\bar"])
+        self.assertEqual(p9.serialise(b'KO', True), [b""])
+        self.assertEqual(p9.serialise(b'SZ', 9), [b"9"])
+        self.assertEqual(p9.serialise(b'KM', 3.5), [b"3.5"])
+        self.assertEqual(p9.serialise(b'C', b"foo\\:b]ar\n"), [b"foo\\\\:b\\]ar\n"])
+        self.assertEqual(p19.serialise(b'B', (1, 2)), [b"cr"])
+        self.assertEqual(p9.serialise(b'B', None), [b"tt"])
+        self.assertEqual(p19.serialise(b'AW', set([(17, 1), (18, 0)])),[b"aa", b"bb"])
+        self.assertEqual(p9.serialise(b'DD', [(1, 2), (3, 4)]), [b"ch", b"ef"])
+        self.assertEqual(p9.serialise(b'DD', []), [b""])
+        self.assertRaisesRegexp(ValueError, "empty list", p9.serialise, b'CR', [])
+        self.assertEqual(p9.serialise(b'AP', (b"na:me", b"2.3")), [b"na\\:me:2.3"])
+        self.assertEqual(p9.serialise(b'FG', (515, b"th]is")), [b"515:th\\]is"])
+        self.assertEqual(p9.serialise(b'XX', b"foo\\bar"), [b"foo\\\\bar"])
 
-        self.assertRaises(ValueError, p9.serialise, 'B', (1, 9))
+        self.assertRaises(ValueError, p9.serialise, b'B', (1, 9))
 
     def test_presenter_private_properties(self):
         p9 = sgf_properties.Presenter(9, "UTF-8")
-        self.assertEqual(p9.serialise('XX', "9"), ["9"])
-        self.assertEqual(p9.interpret('XX', ["9"]), "9")
-        p9.set_private_property_type(p9.get_property_type("SZ"))
-        self.assertEqual(p9.serialise('XX', 9), ["9"])
-        self.assertEqual(p9.interpret('XX', ["9"]), 9)
+        self.assertEqual(p9.serialise(b'XX', b"9"), [b"9"])
+        self.assertEqual(p9.interpret(b'XX', [b"9"]), b"9")
+        p9.set_private_property_type(p9.get_property_type(b"SZ"))
+        self.assertEqual(p9.serialise(b'XX', 9), [b"9"])
+        self.assertEqual(p9.interpret(b'XX', [b"9"]), 9)
         p9.set_private_property_type(None)
         self.assertRaisesRegexp(ValueError, "unknown property",
-                                p9.serialise, 'XX', "foo\\bar")
+                                p9.serialise, b'XX', b"foo\\bar")
         self.assertRaisesRegexp(ValueError, "unknown property",
-                                p9.interpret, 'XX', ["asd"])
+                                p9.interpret, b'XX', [b"asd"])

--- a/tests/gosgf/sgf_properties_test.py
+++ b/tests/gosgf/sgf_properties_test.py
@@ -1,0 +1,379 @@
+"""Tests for sgf_properties.py."""
+
+import unittest
+from textwrap import dedent
+
+from betago.gosgf import sgf_properties
+
+
+class SgfPropertiesTestCase(unittest.TestCase):
+    def test_interpret_simpletext(self):
+        def interpret(s, encoding):
+            context = sgf_properties._Context(19, encoding)
+            return sgf_properties.interpret_simpletext(s, context)
+        self.assertEqual(interpret("a\nb\\\\c", "utf-8"), "a b\\c")
+        u = u"test \N{POUND SIGN}"
+        self.assertEqual(interpret(u.encode("utf-8"), "UTF-8"),
+                         u.encode("utf-8"))
+        self.assertEqual(interpret(u.encode("iso-8859-1"), "ISO-8859-1"),
+                         u.encode("utf-8"))
+        self.assertRaises(UnicodeDecodeError, interpret,
+                          u.encode("iso-8859-1"), "UTF-8")
+        self.assertRaises(UnicodeDecodeError, interpret, u.encode("utf-8"), "ASCII")
+
+    def test_serialise_simpletext(self):
+        def serialise(s, encoding):
+            context = sgf_properties._Context(19, encoding)
+            return sgf_properties.serialise_simpletext(s, context)
+        self.assertEqual(serialise("ab\\c", "utf-8"), "ab\\\\c")
+        u = u"test \N{POUND SIGN}"
+        self.assertEqual(serialise(u.encode("utf-8"), "UTF-8"),
+                         u.encode("utf-8"))
+        self.assertEqual(serialise(u.encode("utf-8"), "ISO-8859-1"),
+                         u.encode("iso-8859-1"))
+        self.assertRaises(UnicodeEncodeError, serialise,
+                          u"\N{EN DASH}".encode("utf-8"), "ISO-8859-1")
+
+    def test_interpret_text(self):
+        def interpret(s, encoding):
+            context = sgf_properties._Context(19, encoding)
+            return sgf_properties.interpret_text(s, context)
+        self.assertEqual(interpret("a\nb\\\\c", "utf-8"), "a\nb\\c")
+        u = u"test \N{POUND SIGN}"
+        self.assertEqual(interpret(u.encode("utf-8"), "UTF-8"),
+                         u.encode("utf-8"))
+        self.assertEqual(interpret(u.encode("iso-8859-1"), "ISO-8859-1"),
+                         u.encode("utf-8"))
+        self.assertRaises(UnicodeDecodeError, interpret,
+                          u.encode("iso-8859-1"), "UTF-8")
+        self.assertRaises(UnicodeDecodeError, interpret, u.encode("utf-8"), "ASCII")
+
+    def test_serialise_text(self):
+        def serialise(s, encoding):
+            context = sgf_properties._Context(19, encoding)
+            return sgf_properties.serialise_text(s, context)
+        self.assertEqual(serialise("ab\\c", "utf-8"), "ab\\\\c")
+        u = u"test \N{POUND SIGN}"
+        self.assertEqual(serialise(u.encode("utf-8"), "UTF-8"),
+                         u.encode("utf-8"))
+        self.assertEqual(serialise(u.encode("utf-8"), "ISO-8859-1"),
+                         u.encode("iso-8859-1"))
+        self.assertRaises(UnicodeEncodeError, serialise,
+                          u"\N{EN DASH}".encode("utf-8"), "ISO-8859-1")
+
+    def test_interpret_number(self):
+        interpret_number = sgf_properties.interpret_number
+        self.assertEqual(interpret_number("1"), 1)
+        self.assertIs(type(interpret_number("1")), int)
+        self.assertEqual(interpret_number("0"), 0)
+        self.assertEqual(interpret_number("-1"), -1)
+        self.assertEqual(interpret_number("+1"), 1)
+        self.assertRaises(ValueError, interpret_number, "1.5")
+        self.assertRaises(ValueError, interpret_number, "0xaf")
+        self.assertRaises(TypeError, interpret_number, 1)
+
+    def test_interpret_real(self):
+        interpret_real = sgf_properties.interpret_real
+        self.assertEqual(interpret_real("1"), 1.0)
+        self.assertIs(type(interpret_real("1")), float)
+        self.assertEqual(interpret_real("0"), 0.0)
+        self.assertEqual(interpret_real("1.0"), 1.0)
+        self.assertEqual(interpret_real("1.5"), 1.5)
+        self.assertEqual(interpret_real("-1.5"), -1.5)
+        self.assertEqual(interpret_real("+0.5"), 0.5)
+        self.assertRaises(ValueError, interpret_real, "+")
+        self.assertRaises(ValueError, interpret_real, "0xaf")
+        self.assertRaises(ValueError, interpret_real, "inf")
+        self.assertRaises(ValueError, interpret_real, "-inf")
+        self.assertRaises(ValueError, interpret_real, "NaN")
+        self.assertRaises(ValueError, interpret_real, "1e400")
+        #self.assertRaises(TypeError, interpret_real, 1.0)
+
+    def test_serialise_real(self):
+        serialise_real = sgf_properties.serialise_real
+        self.assertEqual(serialise_real(1), "1")
+        self.assertEqual(serialise_real(-1), "-1")
+        self.assertEqual(serialise_real(1.0), "1")
+        self.assertEqual(serialise_real(-1.0), "-1")
+        self.assertEqual(serialise_real(1.5), "1.5")
+        self.assertEqual(serialise_real(-1.5), "-1.5")
+        self.assertEqual(serialise_real(0.001), "0.001")
+        self.assertEqual(serialise_real(0.0001), "0.0001")
+        self.assertEqual(serialise_real(0.00001), "0")
+        self.assertEqual(serialise_real(1e15), "1000000000000000")
+        self.assertEqual(serialise_real(1e16), "10000000000000000")
+        self.assertEqual(serialise_real(1e17), "100000000000000000")
+        self.assertEqual(serialise_real(1e18), "1000000000000000000")
+        self.assertEqual(serialise_real(-1e18), "-1000000000000000000")
+        # 1e400 is inf
+        self.assertRaises(ValueError, serialise_real, 1e400)
+        # Python 2.5 returns 0
+        #self.assertRaises(ValueError, serialise_real, float("NaN"))
+
+
+    def test_interpret_move(self):
+        def interpret_move(s, size):
+            context = sgf_properties._Context(size, "UTF-8")
+            return sgf_properties.interpret_move(s, context)
+        self.assertEqual(interpret_move("aa", 19), (18, 0))
+        self.assertEqual(interpret_move("ai", 19), (10, 0))
+        self.assertEqual(interpret_move("ba",  9), (8, 1))
+        self.assertEqual(interpret_move("tt", 21), (1, 19))
+        self.assertIs(interpret_move("tt", 19), None)
+        self.assertIs(interpret_move("", 19), None)
+        self.assertIs(interpret_move("", 21), None)
+        self.assertRaises(ValueError, interpret_move, "Aa", 19)
+        self.assertRaises(ValueError, interpret_move, "aA", 19)
+        self.assertRaises(ValueError, interpret_move, "aaa", 19)
+        self.assertRaises(ValueError, interpret_move, "a", 19)
+        self.assertRaises(ValueError, interpret_move, "au", 19)
+        self.assertRaises(ValueError, interpret_move, "ua", 19)
+        self.assertRaises(ValueError, interpret_move, "a`", 19)
+        self.assertRaises(ValueError, interpret_move, "`a", 19)
+        self.assertRaises(ValueError, interpret_move, "11", 19)
+        self.assertRaises(ValueError, interpret_move, " aa", 19)
+        self.assertRaises(ValueError, interpret_move, "aa\x00", 19)
+        self.assertRaises(TypeError, interpret_move, None, 19)
+        #self.assertRaises(TypeError, interpret_move, ('a', 'a'), 19)
+
+    def test_serialise_move(self):
+        def serialise_move(s, size):
+            context = sgf_properties._Context(size, "UTF-8")
+            return sgf_properties.serialise_move(s, context)
+        self.assertEqual(serialise_move((18, 0), 19), "aa")
+        self.assertEqual(serialise_move((10, 0), 19), "ai")
+        self.assertEqual(serialise_move((8, 1), 19), "bk")
+        self.assertEqual(serialise_move((8, 1), 9), "ba")
+        self.assertEqual(serialise_move((1, 19), 21), "tt")
+        self.assertEqual(serialise_move(None, 19), "tt")
+        self.assertEqual(serialise_move(None, 20), "")
+        self.assertRaises(ValueError, serialise_move, (3, 3), 0)
+        self.assertRaises(ValueError, serialise_move, (3, 3), 27)
+        self.assertRaises(ValueError, serialise_move, (9, 0), 9)
+        self.assertRaises(ValueError, serialise_move, (-1, 0), 9)
+        self.assertRaises(ValueError, serialise_move, (0, 9), 9)
+        self.assertRaises(ValueError, serialise_move, (0, -1), 9)
+        self.assertRaises(TypeError, serialise_move, (1, 1.5), 9)
+
+    def test_interpret_point(self):
+        def interpret_point(s, size):
+            context = sgf_properties._Context(size, "UTF-8")
+            return sgf_properties.interpret_point(s, context)
+        self.assertEqual(interpret_point("aa", 19), (18, 0))
+        self.assertEqual(interpret_point("ai", 19), (10, 0))
+        self.assertEqual(interpret_point("ba",  9), (8, 1))
+        self.assertEqual(interpret_point("tt", 21), (1, 19))
+        self.assertRaises(ValueError, interpret_point, "tt", 19)
+        self.assertRaises(ValueError, interpret_point, "", 19)
+        self.assertRaises(ValueError, interpret_point, "", 21)
+        self.assertRaises(ValueError, interpret_point, "Aa", 19)
+        self.assertRaises(ValueError, interpret_point, "aA", 19)
+        self.assertRaises(ValueError, interpret_point, "aaa", 19)
+        self.assertRaises(ValueError, interpret_point, "a", 19)
+        self.assertRaises(ValueError, interpret_point, "au", 19)
+        self.assertRaises(ValueError, interpret_point, "ua", 19)
+        self.assertRaises(ValueError, interpret_point, "a`", 19)
+        self.assertRaises(ValueError, interpret_point, "`a", 19)
+        self.assertRaises(ValueError, interpret_point, "11", 19)
+        self.assertRaises(ValueError, interpret_point, " aa", 19)
+        self.assertRaises(ValueError, interpret_point, "aa\x00", 19)
+        self.assertRaises(TypeError, interpret_point, None, 19)
+        #self.assertRaises(TypeError, interpret_point, ('a', 'a'), 19)
+
+    def test_serialise_point(self):
+        def serialise_point(s, size):
+            context = sgf_properties._Context(size, "UTF-8")
+            return sgf_properties.serialise_point(s, context)
+        self.assertEqual(serialise_point((18, 0), 19), "aa")
+        self.assertEqual(serialise_point((10, 0), 19), "ai")
+        self.assertEqual(serialise_point((8, 1), 19), "bk")
+        self.assertEqual(serialise_point((8, 1), 9), "ba")
+        self.assertEqual(serialise_point((1, 19), 21), "tt")
+        self.assertRaises(ValueError, serialise_point, None, 19)
+        self.assertRaises(ValueError, serialise_point, None, 20)
+        self.assertRaises(ValueError, serialise_point, (3, 3), 0)
+        self.assertRaises(ValueError, serialise_point, (3, 3), 27)
+        self.assertRaises(ValueError, serialise_point, (9, 0), 9)
+        self.assertRaises(ValueError, serialise_point, (-1, 0), 9)
+        self.assertRaises(ValueError, serialise_point, (0, 9), 9)
+        self.assertRaises(ValueError, serialise_point, (0, -1), 9)
+        self.assertRaises(TypeError, serialise_point, (1, 1.5), 9)
+
+
+    def test_interpret_point_list(self):
+        def ipl(l, size):
+            context = sgf_properties._Context(size, "UTF-8")
+            return sgf_properties.interpret_point_list(l, context)
+        self.assertEqual(ipl([], 19),
+                         set())
+        self.assertEqual(ipl(["aa"], 19),
+                         set([(18, 0)]))
+        self.assertEqual(ipl(["aa", "ai"], 19),
+                         set([(18, 0), (10, 0)]))
+        self.assertEqual(ipl(["ab:bc"], 19),
+                         set([(16, 0), (16, 1), (17, 0), (17, 1)]))
+        self.assertEqual(ipl(["ab:bc", "aa"], 19),
+                         set([(18, 0), (16, 0), (16, 1), (17, 0), (17, 1)]))
+        # overlap is forbidden by the spec, but we accept it
+        self.assertEqual(ipl(["aa", "aa"], 19),
+                         set([(18, 0)]))
+        self.assertEqual(ipl(["ab:bc", "bb:bc"], 19),
+                         set([(16, 0), (16, 1), (17, 0), (17, 1)]))
+        # 1x1 rectangles are forbidden by the spec, but we accept them
+        self.assertEqual(ipl(["aa", "bb:bb"], 19),
+                         set([(18, 0), (17, 1)]))
+        # 'backwards' rectangles are forbidden by the spec, and we reject them
+        self.assertRaises(ValueError, ipl, ["ab:aa"], 19)
+        self.assertRaises(ValueError, ipl, ["ba:aa"], 19)
+        self.assertRaises(ValueError, ipl, ["bb:aa"], 19)
+
+        self.assertRaises(ValueError, ipl, ["aa", "tt"], 19)
+        self.assertRaises(ValueError, ipl, ["aa", ""], 19)
+        self.assertRaises(ValueError, ipl, ["aa:", "aa"], 19)
+        self.assertRaises(ValueError, ipl, ["aa:tt", "aa"], 19)
+        self.assertRaises(ValueError, ipl, ["tt:aa", "aa"], 19)
+
+    def test_compressed_point_list_spec_example(self):
+        # Checks the examples at http://www.red-bean.com/sgf/DD_VW.html
+        def sgf_point(move, size):
+            row, col = move
+            row = size - row - 1
+            col_s = "abcdefghijklmnopqrstuvwxy"[col]
+            row_s = "abcdefghijklmnopqrstuvwxy"[row]
+            return col_s + row_s
+
+        def ipl(l, size):
+            context = sgf_properties._Context(size, "UTF-8")
+            return sgf_properties.interpret_point_list(l, context)
+        self.assertEqual(
+            set(sgf_point(move, 9) for move in ipl(["ac:ic"], 9)),
+            set(["ac", "bc", "cc", "dc", "ec", "fc", "gc", "hc", "ic"]))
+        self.assertEqual(
+            set(sgf_point(move, 9) for move in ipl(["ae:ie"], 9)),
+            set(["ae", "be", "ce", "de", "ee", "fe", "ge", "he", "ie"]))
+        self.assertEqual(
+            set(sgf_point(move, 9) for move in ipl(["aa:bi", "ca:ce"], 9)),
+            set(["aa", "ab", "ac", "ad", "ae", "af", "ag", "ah", "ai",
+                 "bi", "bh", "bg", "bf", "be", "bd", "bc", "bb", "ba",
+                 "ca", "cb", "cc", "cd", "ce"]))
+
+    def test_serialise_point_list(self):
+        def ipl(l, size):
+            context = sgf_properties._Context(size, "UTF-8")
+            return sgf_properties.interpret_point_list(l, context)
+        def spl(l, size):
+            context = sgf_properties._Context(size, "UTF-8")
+            return sgf_properties.serialise_point_list(l, context)
+
+        self.assertEqual(spl([(18, 0), (17, 1)], 19), ['aa', 'bb'])
+        self.assertEqual(spl([(17, 1), (18, 0)], 19), ['aa', 'bb'])
+        self.assertEqual(spl([], 9), [])
+        self.assertEqual(ipl(spl([(1,2), (3,4), (4,5)], 19), 19),
+                         set([(1,2), (3,4), (4,5)]))
+        self.assertRaises(ValueError, spl, [(18, 0), None], 19)
+
+    def test_AP(self):
+        def serialise(arg):
+            context = sgf_properties._Context(19, "UTF-8")
+            return sgf_properties.serialise_AP(arg, context)
+        def interpret(arg):
+            context = sgf_properties._Context(19, "UTF-8")
+            return sgf_properties.interpret_AP(arg, context)
+
+        self.assertEqual(serialise(("foo:bar", "2\n3")), "foo\\:bar:2\n3")
+        self.assertEqual(interpret("foo\\:bar:2 3"), ("foo:bar", "2 3"))
+        self.assertEqual(interpret("foo bar"), ("foo bar", ""))
+
+    def test_ARLN(self):
+        def serialise(arg, size):
+            context = sgf_properties._Context(size, "UTF-8")
+            return sgf_properties.serialise_ARLN_list(arg, context)
+        def interpret(arg, size):
+            context = sgf_properties._Context(size, "UTF-8")
+            return sgf_properties.interpret_ARLN_list(arg, context)
+
+        self.assertEqual(serialise([], 19), [])
+        self.assertEqual(interpret([], 19), [])
+        self.assertEqual(serialise([((7, 0), (5, 2)), ((4, 3), (2, 5))], 9),
+                         ['ab:cd', 'de:fg'])
+        self.assertEqual(interpret(['ab:cd', 'de:fg'], 9),
+                         [((7, 0), (5, 2)), ((4, 3), (2, 5))])
+        self.assertRaises(ValueError, serialise, [((7, 0), None)], 9)
+        self.assertRaises(ValueError, interpret, ['ab:tt', 'de:fg'], 9)
+
+    def test_FG(self):
+        def serialise(arg):
+            context = sgf_properties._Context(19, "UTF-8")
+            return sgf_properties.serialise_FG(arg, context)
+        def interpret(arg):
+            context = sgf_properties._Context(19, "UTF-8")
+            return sgf_properties.interpret_FG(arg, context)
+        self.assertEqual(serialise(None), "")
+        self.assertEqual(interpret(""), None)
+        self.assertEqual(serialise((515, "th]is")), "515:th\\]is")
+        self.assertEqual(interpret("515:th\\]is"), (515, "th]is"))
+
+    def test_LB(self):
+        def serialise(arg, size):
+            context = sgf_properties._Context(size, "UTF-8")
+            return sgf_properties.serialise_LB_list(arg, context)
+        def interpret(arg, size):
+            context = sgf_properties._Context(size, "UTF-8")
+            return sgf_properties.interpret_LB_list(arg, context)
+        self.assertEqual(serialise([], 19), [])
+        self.assertEqual(interpret([], 19), [])
+        self.assertEqual(
+            serialise([((6, 0), "lbl"), ((6, 1), "lb]l2")], 9),
+            ["ac:lbl", "bc:lb\\]l2"])
+        self.assertEqual(
+            interpret(["ac:lbl", "bc:lb\\]l2"], 9),
+            [((6, 0), "lbl"), ((6, 1), "lb]l2")])
+        self.assertRaises(ValueError, serialise, [(None, "lbl")], 9)
+        self.assertRaises(ValueError, interpret, [':lbl', 'de:lbl2'], 9)
+
+    def test_presenter_interpret(self):
+        p9 = sgf_properties.Presenter(9, "UTF-8")
+        p19 = sgf_properties.Presenter(19, "UTF-8")
+        self.assertEqual(p9.interpret('KO', [""]), True)
+        self.assertEqual(p9.interpret('SZ', ["9"]), 9)
+        self.assertRaisesRegexp(ValueError, "multiple values",
+                                p9.interpret, 'SZ', ["9", "blah"])
+        self.assertEqual(p9.interpret('CR', ["ab", "cd"]), set([(5, 2), (7, 0)]))
+        self.assertRaises(ValueError, p9.interpret, 'SZ', [])
+        self.assertRaises(ValueError, p9.interpret, 'CR', [])
+        self.assertEqual(p9.interpret('DD', [""]), set())
+        # all lists are treated like elists
+        self.assertEqual(p9.interpret('CR', [""]), set())
+
+    def test_presenter_serialise(self):
+        p9 = sgf_properties.Presenter(9, "UTF-8")
+        p19 = sgf_properties.Presenter(19, "UTF-8")
+
+        self.assertEqual(p9.serialise('KO', True), [""])
+        self.assertEqual(p9.serialise('SZ', 9), ["9"])
+        self.assertEqual(p9.serialise('KM', 3.5), ["3.5"])
+        self.assertEqual(p9.serialise('C', "foo\\:b]ar\n"), ["foo\\\\:b\\]ar\n"])
+        self.assertEqual(p19.serialise('B', (1, 2)), ["cr"])
+        self.assertEqual(p9.serialise('B', None), ["tt"])
+        self.assertEqual(p19.serialise('AW', set([(17, 1), (18, 0)])),["aa", "bb"])
+        self.assertEqual(p9.serialise('DD', [(1, 2), (3, 4)]), ["ch", "ef"])
+        self.assertEqual(p9.serialise('DD', []), [""])
+        self.assertRaisesRegexp(ValueError, "empty list", p9.serialise, 'CR', [])
+        self.assertEqual(p9.serialise('AP', ("na:me", "2.3")), ["na\\:me:2.3"])
+        self.assertEqual(p9.serialise('FG', (515, "th]is")), ["515:th\\]is"])
+        self.assertEqual(p9.serialise('XX', "foo\\bar"), ["foo\\\\bar"])
+
+        self.assertRaises(ValueError, p9.serialise, 'B', (1, 9))
+
+    def test_presenter_private_properties(self):
+        p9 = sgf_properties.Presenter(9, "UTF-8")
+        self.assertEqual(p9.serialise('XX', "9"), ["9"])
+        self.assertEqual(p9.interpret('XX', ["9"]), "9")
+        p9.set_private_property_type(p9.get_property_type("SZ"))
+        self.assertEqual(p9.serialise('XX', 9), ["9"])
+        self.assertEqual(p9.interpret('XX', ["9"]), 9)
+        p9.set_private_property_type(None)
+        self.assertRaisesRegexp(ValueError, "unknown property",
+                                p9.serialise, 'XX', "foo\\bar")
+        self.assertRaisesRegexp(ValueError, "unknown property",
+                                p9.interpret, 'XX', ["asd"])

--- a/tests/gosgf/sgf_test.py
+++ b/tests/gosgf/sgf_test.py
@@ -1,0 +1,787 @@
+# -*- coding: utf-8 -*-
+"""Tests for sgf.py."""
+
+import unittest
+from textwrap import dedent
+
+from betago import gosgf
+
+SAMPLE_SGF = """\
+(;AP[testsuite:0]CA[utf-8]DT[2009-06-06]FF[4]GM[1]KM[7.5]PB[Black engine]
+PL[B]PW[White engine]RE[W+R]SZ[9]AB[ai][bh][ee]AW[fc][gc];B[dg];W[ef]C[comment
+on two lines];B[];W[tt]C[Final comment])
+"""
+
+SAMPLE_SGF_VAR = """\
+(;AP[testsuite:0]CA[utf-8]DT[2009-06-06]FF[4]GM[1]KM[7.5]PB[Black engine]
+PL[B]RE[W+R]SZ[9]AB[ai][bh][ee]AW[fd][gc]VW[]
+;B[dg]
+;W[ef]C[comment
+on two lines]
+;B[]
+;C[Nonfinal comment]VW[aa:bb]
+(;B[ia];W[ib];B[ic])
+(;B[ib];W[ic]
+  (;B[id])
+  (;B[ie])
+))
+"""
+
+
+class SgfTestCase(unittest.TestCase):
+    def test_new_sgf_game(self):
+        g1 = gosgf.Sgf_game(9)
+        self.assertEqual(g1.get_size(), 9)
+        root = g1.get_root()
+        self.assertEqual(root.get_raw('FF'), '4')
+        self.assertEqual(root.get_raw('GM'), '1')
+        self.assertEqual(root.get_raw('SZ'), '9')
+        self.assertEqual(root.get_raw_property_map(), {
+            'FF': ['4'],
+            'GM': ['1'],
+            'SZ': ['9'],
+            'CA': ['UTF-8'],
+            });
+        self.assertEqual(list(root), [])
+        self.assertEqual(root.parent, None)
+        self.assertIs(root.owner, g1)
+
+    def test_sgf_game_from_coarse_game_tree(self):
+        class Namespace(object):
+            pass
+        coarse_game = Namespace()
+        coarse_game.sequence = [{'SZ' : ["9"]}, {'B' : ["aa"]}]
+        coarse_game.children = []
+        g1 = gosgf.Sgf_game.from_coarse_game_tree(coarse_game)
+        self.assertEqual(g1.get_size(), 9)
+        root = g1.get_root()
+        self.assertIs(root.get_raw_property_map(), coarse_game.sequence[0])
+        self.assertEqual(root.parent, None)
+        self.assertIs(root.owner, g1)
+        self.assertEqual(len(root), 1)
+
+        coarse_game2 = Namespace()
+        coarse_game2.sequence = [{'SZ' : ["0"]}, {'B' : ["aa"]}]
+        coarse_game2.children = []
+        self.assertRaisesRegexp(ValueError, "size out of range: 0",
+                                gosgf.Sgf_game.from_coarse_game_tree, coarse_game2)
+
+    def test_sgf_game_from_string(self):
+        g1 = gosgf.Sgf_game.from_string("(;)")
+        self.assertEqual(g1.get_size(), 19)
+        self.assertRaisesRegexp(ValueError, "unexpected end of SGF data",
+                                gosgf.Sgf_game.from_string, "(;SZ[9]")
+        g2 = gosgf.Sgf_game.from_string("(;SZ[9])")
+        self.assertEqual(g2.get_size(), 9)
+        self.assertRaisesRegexp(ValueError, "bad SZ property: a",
+                                gosgf.Sgf_game.from_string, "(;SZ[a])")
+        self.assertRaisesRegexp(ValueError, "size out of range: 27",
+                              gosgf.Sgf_game.from_string, "(;SZ[27])")
+        self.assertRaisesRegexp(ValueError, "unknown encoding: $",
+                              gosgf.Sgf_game.from_string, "(;CA[])")
+    
+    def test_node(self):
+        sgf_game = gosgf.Sgf_game.from_string(
+            r"(;KM[6.5]C[sample\: comment]AB[ai][bh][ee]AE[];B[dg])")
+        node0 = sgf_game.get_root()
+        node1 = list(sgf_game.main_sequence_iter())[1]
+        self.assertEqual(node0.get_size(), 19)
+        self.assertEqual(node0.get_encoding(), "ISO-8859-1")
+        self.assertIs(node0.has_property('KM'), True)
+        self.assertIs(node0.has_property('XX'), False)
+        self.assertIs(node1.has_property('KM'), False)
+        self.assertEqual(set(node0.properties()), set(["KM", "C", "AB", "AE"]))
+        self.assertEqual(set(node1.properties()), set(["B"]))
+        self.assertEqual(node0.get_raw('C'), r"sample\: comment")
+        self.assertEqual(node0.get_raw('AB'), "ai")
+        self.assertEqual(node0.get_raw('AE'), "")
+        self.assertRaises(KeyError, node0.get_raw, 'XX')
+        self.assertEqual(node0.get_raw_list('KM'), ['6.5'])
+        self.assertEqual(node0.get_raw_list('AB'), ['ai', 'bh', 'ee'])
+        self.assertEqual(node0.get_raw_list('AE'), [''])
+        self.assertRaises(KeyError, node0.get_raw_list, 'XX')
+        self.assertRaises(KeyError, node0.get_raw, 'XX')
+    
+    def test_property_combination(self):
+        sgf_game = gosgf.Sgf_game.from_string("(;XX[1]YY[2]XX[3]YY[4])")
+        node0 = sgf_game.get_root()
+        self.assertEqual(node0.get_raw_list("XX"), ["1", "3"])
+        self.assertEqual(node0.get_raw_list("YY"), ["2", "4"])
+    
+    def test_node_get(self):
+        sgf_game = gosgf.Sgf_game.from_string(dedent(r"""
+        (;AP[testsuite:0]CA[utf-8]DT[2009-06-06]FF[4]GM[1]KM[7.5]PB[Black engine]
+        PL[B]PW[White engine][xs]RE[W+R]SZ[9]AB[ai][bh][ee]AW[fd][gc]AE[]BM[2]VW[]
+        EV[Test
+        event]
+        C[123:\)
+        abc]
+        YY[none
+        sense]
+        ;B[dg]KO[]AR[ab:cd][de:fg]FG[515:first move]
+        LB[ac:lbl][bc:lbl2])
+        """))
+        root = sgf_game.get_root()
+        node1 = list(sgf_game.main_sequence_iter())[1]
+        self.assertRaises(KeyError, root.get, 'XX')
+        self.assertEqual(root.get('C'), "123:)\nabc")          # Text
+        self.assertEqual(root.get('EV'), "Test event")         # Simpletext
+        self.assertEqual(root.get('BM'), 2)                    # Double
+        self.assertEqual(root.get('YY'), "none\nsense")        # unknown (Text)
+        self.assertIs(node1.get('KO'), True)                   # None
+        self.assertEqual(root.get('KM'), 7.5)                  # Real
+        self.assertEqual(root.get('GM'), 1)                    # Number
+        self.assertEqual(root.get('PL'), 'b')                  # Color
+        self.assertEqual(node1.get('B'), (2, 3))               # Point
+        self.assertEqual(root.get('AB'),
+                       set([(0, 0), (1, 1), (4, 4)]))        # List of Point
+        self.assertEqual(root.get('VW'), set())                # Empty elist
+        self.assertEqual(root.get('AP'), ("testsuite", "0"))   # Application
+        self.assertEqual(node1.get('AR'),
+                       [((7, 0), (5, 2)), ((4, 3), (2, 5))]) # Arrow
+        self.assertEqual(node1.get('FG'), (515, "first move")) # Figure
+        self.assertEqual(node1.get('LB'),
+                       [((6, 0), "lbl"), ((6, 1), "lbl2")])  # Label
+        # Check we (leniently) treat lists like elists on read
+        self.assertEqual(root.get('AE'), set())
+        self.assertRaisesRegexp(ValueError, "multiple values", root.get, 'PW')
+    
+    def test_text_values(self):
+        def check(s):
+            sgf_game = gosgf.Sgf_game.from_string(s)
+            return sgf_game.get_root().get("C")
+        # Round-trip check of Text values through tokeniser, parser, and
+        # text_value().
+        self.assertEqual(check(r"(;C[abc]KO[])"), r"abc")
+        self.assertEqual(check(r"(;C[a\\bc]KO[])"), r"a\bc")
+        self.assertEqual(check(r"(;C[a\\bc\]KO[])"), r"a\bc]KO[")
+        self.assertEqual(check(r"(;C[abc\\]KO[])"), r"abc" + "\\")
+        self.assertEqual(check(r"(;C[abc\\\]KO[])"), r"abc\]KO[")
+        self.assertEqual(check(r"(;C[abc\\\\]KO[])"), r"abc" + "\\\\")
+        self.assertEqual(check(r"(;C[abc\\\\\]KO[])"), r"abc\\]KO[")
+        self.assertEqual(check(r"(;C[xxx :\) yyy]KO[])"), r"xxx :) yyy")
+        self.assertEqual(check("(;C[ab\\\nc])"), "abc")
+        self.assertEqual(check("(;C[ab\nc])"), "ab\nc")
+
+
+
+    def test_node_string(self):
+        sgf_game = gosgf.Sgf_game.from_string(SAMPLE_SGF)
+        node = sgf_game.get_root()
+        self.assertMultiLineEqual(str(node), dedent("""\
+        AB[ai][bh][ee]
+        AP[testsuite:0]
+        AW[fc][gc]
+        CA[utf-8]
+        DT[2009-06-06]
+        FF[4]
+        GM[1]
+        KM[7.5]
+        PB[Black engine]
+        PL[B]
+        PW[White engine]
+        RE[W+R]
+        SZ[9]
+        """))
+
+    def test_node_get_move(self):
+        sgf_game = gosgf.Sgf_game.from_string(SAMPLE_SGF)
+        nodes = list(sgf_game.main_sequence_iter())
+        self.assertEqual(nodes[0].get_move(), (None, None))
+        self.assertEqual(nodes[1].get_move(), ('b', (2, 3)))
+        self.assertEqual(nodes[2].get_move(), ('w', (3, 4)))
+        self.assertEqual(nodes[3].get_move(), ('b', None))
+        self.assertEqual(nodes[4].get_move(), ('w', None))
+
+    def test_node_get_setup_stones(self):
+        sgf_game = gosgf.Sgf_game.from_string(
+            r"(;KM[6.5]SZ[9]C[sample\: comment]AB[ai][bh][ee]AE[bb];B[dg])")
+        node0 = sgf_game.get_root()
+        node1 = list(sgf_game.main_sequence_iter())[1]
+        self.assertIs(node0.has_setup_stones(), True)
+        self.assertIs(node1.has_setup_stones(), False)
+        self.assertEqual(node0.get_setup_stones(),
+                       (set([(0, 0), (1, 1), (4, 4)]), set(), set([(7, 1)])))
+        self.assertEqual(node1.get_setup_stones(),
+                       (set(), set(), set()))
+
+    def test_sgf_game(self):
+        sgf_game = gosgf.Sgf_game.from_string(SAMPLE_SGF_VAR)
+        nodes = list(sgf_game.main_sequence_iter())
+        self.assertEqual(sgf_game.get_size(), 9)
+        self.assertEqual(sgf_game.get_komi(), 7.5)
+        self.assertIs(sgf_game.get_handicap(), None)
+        self.assertEqual(sgf_game.get_player_name('b'), "Black engine")
+        self.assertIs(sgf_game.get_player_name('w'), None)
+        self.assertEqual(sgf_game.get_winner(), 'w')
+        self.assertEqual(nodes[2].get('C'), "comment\non two lines")
+        self.assertEqual(nodes[4].get('C'), "Nonfinal comment")
+
+        g2 = gosgf.Sgf_game.from_string("(;)")
+        self.assertEqual(g2.get_size(), 19)
+        self.assertEqual(g2.get_komi(), 0.0)
+        self.assertIs(g2.get_handicap(), None)
+        self.assertIs(g2.get_player_name('b'), None)
+        self.assertIs(g2.get_player_name('w'), None)
+        self.assertEqual(g2.get_winner(), None)
+
+    def test_tree_view(self):
+        sgf_game = gosgf.Sgf_game.from_string(SAMPLE_SGF_VAR)
+        root = sgf_game.get_root()
+        self.assertIsInstance(root, gosgf.Tree_node)
+        self.assertIs(root.parent, None)
+        self.assertIs(root.owner, sgf_game)
+        self.assertEqual(len(root), 1)
+        self.assertEqual(root[0].get_raw('B'), "dg")
+        self.assertTrue(root)
+        self.assertEqual(root.index(root[0]), 0)
+
+        branchnode = root[0][0][0][0]
+        self.assertIsInstance(branchnode, gosgf.Tree_node)
+        self.assertIs(branchnode.parent, root[0][0][0])
+        self.assertIs(branchnode.owner, sgf_game)
+        self.assertEqual(len(branchnode), 2)
+        self.assertIs(branchnode[1], branchnode[-1])
+        self.assertEqual(branchnode[:1], [branchnode[0]])
+        self.assertEqual([node for node in branchnode],
+                       [branchnode[0], branchnode[1]])
+        with self.assertRaises(IndexError):
+            branchnode[2]
+        self.assertEqual(branchnode[0].get_raw('B'), "ia")
+        self.assertEqual(branchnode[1].get_raw('B'), "ib")
+        self.assertEqual(branchnode.index(branchnode[0]), 0)
+        self.assertEqual(branchnode.index(branchnode[1]), 1)
+
+        self.assertEqual(len(branchnode[1][0]), 2)
+
+        leaf = branchnode[1][0][1]
+        self.assertIs(leaf.parent, branchnode[1][0])
+        self.assertEqual(len(leaf), 0)
+        self.assertFalse(leaf)
+
+        self.assertIs(sgf_game.get_last_node(), root[0][0][0][0][0][0][0])
+
+        # check nothing breaks when first retrieval is by index
+        game2 = gosgf.Sgf_game.from_string(SAMPLE_SGF)
+        root2 = game2.get_root()
+        self.assertEqual(root2[0].get_raw('B'), "dg")
+
+    def test_serialise(self):
+        # Doesn't cover transcoding
+        sgf_game = gosgf.Sgf_game.from_string(SAMPLE_SGF_VAR)
+        serialised = sgf_game.serialise()
+        self.assertEqual(serialised, dedent("""\
+        (;FF[4]AB[ai][bh][ee]AP[testsuite:0]AW[fd][gc]CA[utf-8]DT[2009-06-06]GM[1]
+        KM[7.5]PB[Black engine]PL[B]RE[W+R]SZ[9]VW[];B[dg];C[comment
+        on two lines]W[ef]
+        ;B[];C[Nonfinal comment]VW[aa:bb](;B[ia];W[ib];B[ic])(;B[ib];W[ic](;B[id])(;
+        B[ie])))
+        """))
+        sgf_game2 = gosgf.Sgf_game.from_string(serialised)
+        self.assertEqual(map(str, sgf_game.get_main_sequence()),
+                         map(str, sgf_game2.get_main_sequence()))
+
+    def test_serialise_wrap(self):
+        sgf_game = gosgf.Sgf_game.from_string(SAMPLE_SGF_VAR)
+        serialised = sgf_game.serialise(wrap=None)
+        self.assertEqual(serialised, dedent("""\
+        (;FF[4]AB[ai][bh][ee]AP[testsuite:0]AW[fd][gc]CA[utf-8]DT[2009-06-06]GM[1]KM[7.5]PB[Black engine]PL[B]RE[W+R]SZ[9]VW[];B[dg];C[comment
+        on two lines]W[ef];B[];C[Nonfinal comment]VW[aa:bb](;B[ia];W[ib];B[ic])(;B[ib];W[ic](;B[id])(;B[ie])))
+        """))
+        sgf_game2 = gosgf.Sgf_game.from_string(serialised)
+        self.assertEqual(map(str, sgf_game.get_main_sequence()),
+                         map(str, sgf_game2.get_main_sequence()))
+
+    def test_encoding(self):
+        g1 = gosgf.Sgf_game(19)
+        self.assertEqual(g1.get_charset(), "UTF-8")
+        root = g1.get_root()
+        self.assertEqual(root.get_encoding(), "UTF-8")
+        root.set("C", "£")
+        self.assertEqual(root.get("C"), "£")
+        self.assertEqual(root.get_raw("C"), "£")
+        self.assertEqual(g1.serialise(), dedent("""\
+        (;FF[4]C[£]CA[UTF-8]GM[1]SZ[19])
+        """))
+    
+        g2 = gosgf.Sgf_game(19, encoding="iso-8859-1")
+        self.assertEqual(g2.get_charset(), "ISO-8859-1")
+        root = g2.get_root()
+        self.assertEqual(root.get_encoding(), "ISO-8859-1")
+        root.set("C", "£")
+        self.assertEqual(root.get("C"), "£")
+        self.assertEqual(root.get_raw("C"), "\xa3")
+        self.assertEqual(g2.serialise(), dedent("""\
+        (;FF[4]C[\xa3]CA[ISO-8859-1]GM[1]SZ[19])
+        """))
+    
+        self.assertRaisesRegexp(ValueError, "unknown encoding: unknownencoding",
+                              gosgf.Sgf_game, 19, "unknownencoding")
+    
+    
+    def test_loaded_sgf_game_encoding(self):
+        g1 = gosgf.Sgf_game.from_string("""
+        (;FF[4]C[£]CA[utf-8]GM[1]SZ[19])
+        """)
+        self.assertEqual(g1.get_charset(), "UTF-8")
+        root = g1.get_root()
+        self.assertEqual(root.get_encoding(), "UTF-8")
+        self.assertEqual(root.get("C"), "£")
+        self.assertEqual(root.get_raw("C"), "£")
+        self.assertEqual(g1.serialise(), dedent("""\
+        (;FF[4]C[£]CA[utf-8]GM[1]SZ[19])
+        """))
+    
+        g2 = gosgf.Sgf_game.from_string("""
+        (;FF[4]C[\xa3]CA[iso-8859-1]GM[1]SZ[19])
+        """)
+        self.assertEqual(g2.get_charset(), "ISO-8859-1")
+        root = g2.get_root()
+        self.assertEqual(root.get_encoding(), "ISO-8859-1")
+        self.assertEqual(root.get("C"), "£")
+        self.assertEqual(root.get_raw("C"), "\xa3")
+        self.assertEqual(g2.serialise(), dedent("""\
+        (;FF[4]C[\xa3]CA[iso-8859-1]GM[1]SZ[19])
+        """))
+    
+        g3 = gosgf.Sgf_game.from_string("""
+        (;FF[4]C[\xa3]GM[1]SZ[19])
+        """)
+        self.assertEqual(g3.get_charset(), "ISO-8859-1")
+        root = g3.get_root()
+        self.assertEqual(root.get_encoding(), "ISO-8859-1")
+        self.assertEqual(root.get("C"), "£")
+        self.assertEqual(root.get_raw("C"), "\xa3")
+        self.assertEqual(g3.serialise(), dedent("""\
+        (;FF[4]C[\xa3]GM[1]SZ[19])
+        """))
+    
+        # This is invalidly encoded. get() notices, but serialise() doesn't care.
+        g4 = gosgf.Sgf_game.from_string("""
+        (;FF[4]C[\xa3]CA[utf-8]GM[1]SZ[19])
+        """)
+        self.assertEqual(g4.get_charset(), "UTF-8")
+        root = g4.get_root()
+        self.assertEqual(root.get_encoding(), "UTF-8")
+        self.assertRaises(UnicodeDecodeError, root.get, "C")
+        self.assertEqual(root.get_raw("C"), "\xa3")
+        self.assertEqual(g4.serialise(), dedent("""\
+        (;FF[4]C[\xa3]CA[utf-8]GM[1]SZ[19])
+        """))
+    
+        self.assertRaisesRegexp(
+            ValueError, "unknown encoding: unknownencoding",
+            gosgf.Sgf_game.from_string, """
+            (;FF[4]CA[unknownencoding]GM[1]SZ[19])
+            """)
+    
+    def test_override_encoding(self):
+        g1 = gosgf.Sgf_game.from_string("""
+        (;FF[4]C[£]CA[iso-8859-1]GM[1]SZ[19])
+        """, override_encoding="utf-8")
+        root = g1.get_root()
+        self.assertEqual(root.get_encoding(), "UTF-8")
+        self.assertEqual(root.get("C"), "£")
+        self.assertEqual(root.get_raw("C"), "£")
+        self.assertEqual(g1.serialise(), dedent("""\
+        (;FF[4]C[£]CA[UTF-8]GM[1]SZ[19])
+        """))
+    
+        g2 = gosgf.Sgf_game.from_string("""
+        (;FF[4]C[\xa3]CA[utf-8]GM[1]SZ[19])
+        """, override_encoding="iso-8859-1")
+        root = g2.get_root()
+        self.assertEqual(root.get_encoding(), "ISO-8859-1")
+        self.assertEqual(root.get("C"), "£")
+        self.assertEqual(root.get_raw("C"), "\xa3")
+        self.assertEqual(g2.serialise(), dedent("""\
+        (;FF[4]C[\xa3]CA[ISO-8859-1]GM[1]SZ[19])
+        """))
+    
+    def test_serialise_transcoding(self):
+        g1 = gosgf.Sgf_game.from_string("""
+        (;FF[4]C[£]CA[utf-8]GM[1]SZ[19])
+        """)
+        self.assertEqual(g1.serialise(), dedent("""\
+        (;FF[4]C[£]CA[utf-8]GM[1]SZ[19])
+        """))
+        g1.get_root().set("CA", "latin-1")
+        self.assertEqual(g1.serialise(), dedent("""\
+        (;FF[4]C[\xa3]CA[latin-1]GM[1]SZ[19])
+        """))
+        g1.get_root().set("CA", "unknown")
+        self.assertRaisesRegexp(ValueError, "unsupported charset: \['unknown']",
+                              g1.serialise)
+    
+        # improperly-encoded from the start
+        g2 = gosgf.Sgf_game.from_string("""
+        (;FF[4]C[£]CA[ascii]GM[1]SZ[19])
+        """)
+        self.assertEqual(g2.serialise(), dedent("""\
+        (;FF[4]C[£]CA[ascii]GM[1]SZ[19])
+        """))
+        g2.get_root().set("CA", "utf-8")
+        self.assertRaises(UnicodeDecodeError, g2.serialise)
+    
+        g3 = gosgf.Sgf_game.from_string("""
+        (;FF[4]C[Δ]CA[utf-8]GM[1]SZ[19])
+        """)
+        g3.get_root().unset("CA")
+        self.assertRaises(UnicodeEncodeError, g3.serialise)
+    
+    def test_tree_mutation(self):
+        sgf_game = gosgf.Sgf_game(9)
+        root = sgf_game.get_root()
+        n1 = root.new_child()
+        n1.set("N", "n1")
+        n2 = root.new_child()
+        n2.set("N", "n2")
+        n3 = n1.new_child()
+        n3.set("N", "n3")
+        n4 = root.new_child(1)
+        n4.set("N", "n4")
+        self.assertEqual(
+            sgf_game.serialise(),
+            "(;FF[4]CA[UTF-8]GM[1]SZ[9](;N[n1];N[n3])(;N[n4])(;N[n2]))\n")
+        self.assertEqual(
+            [node.get_raw_property_map() for node in sgf_game.main_sequence_iter()],
+            [node.get_raw_property_map() for node in root, root[0], n3])
+        self.assertIs(sgf_game.get_last_node(), n3)
+    
+        n1.delete()
+        self.assertEqual(
+            sgf_game.serialise(),
+            "(;FF[4]CA[UTF-8]GM[1]SZ[9](;N[n4])(;N[n2]))\n")
+        self.assertRaises(ValueError, root.delete)
+    
+    def test_tree_mutation_from_coarse_game(self):
+        sgf_game = gosgf.Sgf_game.from_string("(;SZ[9](;N[n1];N[n3])(;N[n2]))")
+        root = sgf_game.get_root()
+        n4 = root.new_child()
+        n4.set("N", "n4")
+        n3 = root[0][0]
+        self.assertEqual(n3.get("N"), "n3")
+        n5 = n3.new_child()
+        n5.set("N", "n5")
+        self.assertEqual(sgf_game.serialise(),
+                       "(;SZ[9](;N[n1];N[n3];N[n5])(;N[n2])(;N[n4]))\n")
+        self.assertEqual(
+            [node.get_raw_property_map() for node in sgf_game.main_sequence_iter()],
+            [node.get_raw_property_map() for node in root, root[0], n3, n5])
+        self.assertIs(sgf_game.get_last_node(), n5)
+        n3.delete()
+        self.assertEqual(sgf_game.serialise(),
+                       "(;SZ[9](;N[n1])(;N[n2])(;N[n4]))\n")
+        self.assertRaises(ValueError, root.delete)
+    
+    def test_tree_new_child_with_unexpanded_root_and_index(self):
+        sgf_game = gosgf.Sgf_game.from_string("(;SZ[9](;N[n1];N[n3])(;N[n2]))")
+        root = sgf_game.get_root()
+        n4 = root.new_child(2)
+        n4.set("N", "n4")
+        self.assertEqual(sgf_game.serialise(),
+                       "(;SZ[9](;N[n1];N[n3])(;N[n2])(;N[n4]))\n")
+    
+    def test_reparent(self):
+        g1 = gosgf.Sgf_game.from_string("(;SZ[9](;N[n1];N[n3])(;N[n2]))")
+        root = g1.get_root()
+        # Test with unexpanded root
+        self.assertRaisesRegexp(ValueError, "would create a loop",
+                              root.reparent, root)
+        n1 = root[0]
+        n2 = root[1]
+        n3 = root[0][0]
+        self.assertEqual(n1.get("N"), "n1")
+        self.assertEqual(n2.get("N"), "n2")
+        self.assertEqual(n3.get("N"), "n3")
+        n3.reparent(n2)
+        self.assertEqual(g1.serialise(), "(;SZ[9](;N[n1])(;N[n2];N[n3]))\n")
+        n3.reparent(n2)
+        self.assertEqual(g1.serialise(), "(;SZ[9](;N[n1])(;N[n2];N[n3]))\n")
+        self.assertRaisesRegexp(ValueError, "would create a loop",
+                              root.reparent, n3)
+        self.assertRaisesRegexp(ValueError, "would create a loop",
+                              n3.reparent, n3)
+        g2 = gosgf.Sgf_game(9)
+        self.assertRaisesRegexp(
+            ValueError, "new parent doesn't belong to the same game",
+            n3.reparent, g2.get_root())
+    
+    def test_reparent_index(self):
+        g1 = gosgf.Sgf_game.from_string("(;SZ[9](;N[n1];N[n3])(;N[n2]))")
+        root = g1.get_root()
+        n1 = root[0]
+        n2 = root[1]
+        n3 = root[0][0]
+        self.assertEqual(n1.get("N"), "n1")
+        self.assertEqual(n2.get("N"), "n2")
+        self.assertEqual(n3.get("N"), "n3")
+        n3.reparent(root, index=1)
+        self.assertEqual(g1.serialise(), "(;SZ[9](;N[n1])(;N[n3])(;N[n2]))\n")
+        n3.reparent(root, index=1)
+        self.assertEqual(g1.serialise(), "(;SZ[9](;N[n1])(;N[n3])(;N[n2]))\n")
+        n3.reparent(root, index=2)
+        self.assertEqual(g1.serialise(), "(;SZ[9](;N[n1])(;N[n2])(;N[n3]))\n")
+    
+    def test_extend_main_sequence(self):
+        g1 = gosgf.Sgf_game(9)
+        for i in xrange(6):
+            g1.extend_main_sequence().set("N", "e%d" % i)
+        self.assertEqual(
+            g1.serialise(),
+            "(;FF[4]CA[UTF-8]GM[1]SZ[9];N[e0];N[e1];N[e2];N[e3];N[e4];N[e5])\n")
+        g2 = gosgf.Sgf_game.from_string("(;SZ[9](;N[n1];N[n3])(;N[n2]))")
+        for i in xrange(6):
+            g2.extend_main_sequence().set("N", "e%d" % i)
+        self.assertEqual(
+            g2.serialise(),
+            "(;SZ[9](;N[n1];N[n3];N[e0];N[e1];N[e2];N[e3];N[e4];N[e5])(;N[n2]))\n")
+
+    def test_get_sequence_above(self):
+        sgf_game = gosgf.Sgf_game.from_string(SAMPLE_SGF_VAR)
+        root = sgf_game.get_root()
+        branchnode = root[0][0][0][0]
+        leaf = branchnode[1][0][1]
+        self.assertEqual(sgf_game.get_sequence_above(root), [])
+
+        self.assertEqual(sgf_game.get_sequence_above(branchnode),
+                         [root, root[0], root[0][0], root[0][0][0]])
+
+        self.assertEqual(sgf_game.get_sequence_above(leaf),
+                         [root, root[0], root[0][0], root[0][0][0],
+                          branchnode, branchnode[1], branchnode[1][0]])
+
+        sgf_game2 = gosgf.Sgf_game.from_string(SAMPLE_SGF_VAR)
+        self.assertRaisesRegexp(ValueError, "node doesn't belong to this game",
+                                sgf_game2.get_sequence_above, leaf)
+
+    def test_get_main_sequence_below(self):
+        sgf_game = gosgf.Sgf_game.from_string(SAMPLE_SGF_VAR)
+        root = sgf_game.get_root()
+        branchnode = root[0][0][0][0]
+        leaf = branchnode[1][0][1]
+        self.assertEqual(sgf_game.get_main_sequence_below(leaf), [])
+
+        self.assertEqual(sgf_game.get_main_sequence_below(branchnode),
+                         [branchnode[0], branchnode[0][0], branchnode[0][0][0]])
+
+        self.assertEqual(sgf_game.get_main_sequence_below(root),
+                         [root[0], root[0][0], root[0][0][0], branchnode,
+                          branchnode[0], branchnode[0][0], branchnode[0][0][0]])
+
+        sgf_game2 = gosgf.Sgf_game.from_string(SAMPLE_SGF_VAR)
+        self.assertRaisesRegexp(ValueError, "node doesn't belong to this game",
+                              sgf_game2.get_main_sequence_below, branchnode)
+
+    def test_main_sequence(self):
+        sgf_game = gosgf.Sgf_game.from_string(SAMPLE_SGF_VAR)
+        root = sgf_game.get_root()
+
+        nodes = list(sgf_game.main_sequence_iter())
+        self.assertEqual(len(nodes), 8)
+        self.assertIs(root.get_raw_property_map(),
+                    nodes[0].get_raw_property_map())
+        # Check that main_sequence_iter() optimisation has been used.
+        # (Have to call this before making the tree expand.)
+        with self.assertRaises(AttributeError):
+            nodes[1].parent
+    
+        tree_nodes = sgf_game.get_main_sequence()
+        self.assertEqual(len(tree_nodes), 8)
+        self.assertIs(root.get_raw_property_map(),
+                    tree_nodes[0].get_raw_property_map())
+        self.assertIs(tree_nodes[0], root)
+        self.assertIs(tree_nodes[2].parent, tree_nodes[1])
+        self.assertIs(sgf_game.get_last_node(), tree_nodes[-1])
+
+        tree_node = root
+        for node in nodes:
+            self.assertIs(tree_node.get_raw_property_map(),
+                        node.get_raw_property_map())
+            if tree_node:
+                tree_node = tree_node[0]
+
+    def test_find(self):
+        sgf_game = gosgf.Sgf_game.from_string(SAMPLE_SGF_VAR)
+        root = sgf_game.get_root()
+        branchnode = root[0][0][0][0]
+        leaf = branchnode[1][0][1]
+
+        self.assertEqual(root.get("VW"), set())
+        self.assertIs(root.find("VW"), root)
+        self.assertRaises(KeyError, root[0].get, "VW")
+        self.assertEqual(root[0].find_property("VW"), set())
+        self.assertIs(root[0].find("VW"), root)
+
+        self.assertEqual(branchnode.get("VW"),
+                       set([(7, 0), (7, 1), (8, 0), (8, 1)]))
+        self.assertIs(branchnode.find("VW"), branchnode)
+        self.assertEqual(branchnode.find_property("VW"),
+                       set([(7, 0), (7, 1), (8, 0), (8, 1)]))
+
+        self.assertRaises(KeyError, leaf.get, "VW")
+        self.assertIs(leaf.find("VW"), branchnode)
+        self.assertEqual(leaf.find_property("VW"),
+                       set([(7, 0), (7, 1), (8, 0), (8, 1)]))
+
+        self.assertIs(leaf.find("XX"), None)
+        self.assertRaises(KeyError, leaf.find_property, "XX")
+
+    def test_node_set_raw(self):
+        sgf_game = gosgf.Sgf_game.from_string(dedent(r"""
+        (;AP[testsuite:0]CA[utf-8]DT[2009-06-06]FF[4]GM[1]KM[7.5]
+        PB[Black engine]PW[White engine]RE[W+R]SZ[9]
+        AB[ai][bh][ee]AW[fd][gc]BM[2]VW[]
+        PL[B]
+        C[123abc]
+        ;B[dg]C[first move])
+        """))
+        root = sgf_game.get_root()
+        self.assertEqual(root.get_raw('RE'), "W+R")
+        root.set_raw('RE', "W+2.5")
+        self.assertEqual(root.get_raw('RE'), "W+2.5")
+        self.assertRaises(KeyError, root.get_raw, 'XX')
+        root.set_raw('XX', "xyz")
+        self.assertEqual(root.get_raw('XX'), "xyz")
+    
+        root.set_raw_list('XX', ("abc", "def"))
+        self.assertEqual(root.get_raw('XX'), "abc")
+        self.assertEqual(root.get_raw_list('XX'), ["abc", "def"])
+    
+        self.assertRaisesRegexp(ValueError, "empty property list",
+                              root.set_raw_list, 'B', [])
+    
+        values = ["123", "456"]
+        root.set_raw_list('YY', values)
+        self.assertEqual(root.get_raw_list('YY'), ["123", "456"])
+        values.append("789")
+        self.assertEqual(root.get_raw_list('YY'), ["123", "456"])
+    
+        self.assertRaisesRegexp(ValueError, "ill-formed property identifier",
+                              root.set_raw, 'Black', "aa")
+        self.assertRaisesRegexp(ValueError, "ill-formed property identifier",
+                              root.set_raw_list, 'Black', ["aa"])
+    
+        root.set_raw('C', "foo\\]bar")
+        self.assertEqual(root.get_raw('C'), "foo\\]bar")
+        root.set_raw('C', "abc\\\\")
+        self.assertEqual(root.get_raw('C'), "abc\\\\")
+        self.assertRaisesRegexp(ValueError, "ill-formed raw property value",
+                              root.set_raw, 'C', "foo]bar")
+        self.assertRaisesRegexp(ValueError, "ill-formed raw property value",
+                              root.set_raw, 'C', "abc\\")
+        self.assertRaisesRegexp(ValueError, "ill-formed raw property value",
+                              root.set_raw_list, 'C', ["abc", "de]f"])
+    
+        root.set_raw('C', "foo\\]bar\\\nbaz")
+        self.assertEqual(root.get('C'), "foo]barbaz")
+
+    def test_node_aliasing(self):
+        # Check that node objects retrieved by different means use the same
+        # property map.
+
+        sgf_game = gosgf.Sgf_game.from_string(dedent(r"""
+        (;C[root];C[node 1])
+        """))
+        root = sgf_game.get_root()
+        plain_node = list(sgf_game.main_sequence_iter())[1]
+        tree_node = root[0]
+        # Check the main_sequence_iter() optimisation was used, otherwise this test
+        # isn't checking what it's supposed to.
+        self.assertIsNot(tree_node, plain_node)
+        self.assertIs(tree_node.__class__, gosgf.Tree_node)
+        self.assertIs(plain_node.__class__, gosgf.Node)
+
+        self.assertEqual(tree_node.get_raw('C'), "node 1")
+        tree_node.set_raw('C', r"test\value")
+        self.assertEqual(tree_node.get_raw('C'), r"test\value")
+        self.assertEqual(plain_node.get_raw('C'), r"test\value")
+
+        plain_node.set_raw_list('XX', ["1", "2", "3"])
+        self.assertEqual(tree_node.get_raw_list('XX'), ["1", "2", "3"])
+
+    def test_node_set(self):
+        sgf_game = gosgf.Sgf_game.from_string("(;FF[4]GM[1]SZ[9])")
+        root = sgf_game.get_root()
+        root.set("KO", True)
+        root.set("KM", 0.5)
+        root.set('DD', [(3, 4), (5, 6)])
+        root.set('AB', set([(0, 0), (1, 1), (4, 4)]))
+        root.set('TW', set())
+        root.set('XX', "nonsense [none]sense more n\\onsens\\e")
+    
+        self.assertEqual(sgf_game.serialise(), dedent("""\
+        (;FF[4]AB[ai][bh][ee]DD[ef][gd]GM[1]KM[0.5]KO[]SZ[9]TW[]
+        XX[nonsense [none\\]sense more n\\\\onsens\\\\e])
+        """))
+    
+    def test_node_unset(self):
+        sgf_game = gosgf.Sgf_game.from_string("(;FF[4]GM[1]SZ[9]HA[3])")
+        root = sgf_game.get_root()
+        self.assertEqual(root.get('HA'), 3)
+        root.unset('HA')
+        self.assertRaises(KeyError, root.unset, 'PL')
+        self.assertEqual(sgf_game.serialise(),
+                       "(;FF[4]GM[1]SZ[9])\n")
+    
+    def test_set_and_unset_size(self):
+        g1 = gosgf.Sgf_game.from_string("(;FF[4]GM[1]SZ[9]HA[3])")
+        root1 = g1.get_root()
+        self.assertRaisesRegexp(ValueError, "changing size is not permitted",
+                              root1.set, "SZ", 19)
+        root1.set("SZ", 9)
+        self.assertRaisesRegexp(ValueError, "changing size is not permitted",
+                              root1.unset, "SZ")
+        g2 = gosgf.Sgf_game.from_string("(;FF[4]GM[1]SZ[19]HA[3])")
+        root2 = g2.get_root()
+        root2.unset("SZ")
+        root2.set("SZ", 19)
+    
+    def test_set_and_unset_charset(self):
+        g1 = gosgf.Sgf_game.from_string("(;FF[4]CA[utf-8]GM[1]SZ[9]HA[3])")
+        self.assertEqual(g1.get_charset(), "UTF-8")
+        root1 = g1.get_root()
+        root1.unset("CA")
+        self.assertEqual(g1.get_charset(), "ISO-8859-1")
+        root1.set("CA", "iso-8859-1")
+        self.assertEqual(g1.get_charset(), "ISO-8859-1")
+        root1.set("CA", "ascii")
+        self.assertEqual(g1.get_charset(), "ASCII")
+        root1.set("CA", "unknownencoding")
+        self.assertRaisesRegexp(ValueError,
+                              "no codec available for CA unknownencoding",
+                              g1.get_charset)
+    
+    def test_node_set_move(self):
+        sgf_game = gosgf.Sgf_game.from_string("(;FF[4]GM[1]SZ[9];B[aa];B[bb])")
+        root, n1, n2 = sgf_game.get_main_sequence()
+        self.assertEqual(root.get_move(), (None, None))
+        root.set_move('b', (1, 1))
+        n1.set_move('w', (1, 2))
+        n2.set_move('b', None)
+        self.assertEqual(root.get('B'), (1, 1))
+        self.assertRaises(KeyError, root.get, 'W')
+        self.assertEqual(n1.get('W'), (1, 2))
+        self.assertRaises(KeyError, n1.get, 'B')
+        self.assertEqual(n2.get('B'), None)
+        self.assertRaises(KeyError, n2.get, 'W')
+
+    def test_node_setup_stones(self):
+        sgf_game = gosgf.Sgf_game.from_string("(;FF[4]GM[1]SZ[9]AW[aa:bb])")
+        root = sgf_game.get_root()
+        root.set_setup_stones(
+            [(1, 2), (3, 4)],
+            set(),
+            [(1, 3), (4, 5)],
+            )
+        self.assertEqual(root.get('AB'), set([(1, 2), (3, 4)]))
+        self.assertRaises(KeyError, root.get, 'AW')
+        self.assertEqual(root.get('AE'), set([(1, 3), (4, 5)]))
+
+    def test_add_comment_text(self):
+        sgf_game = gosgf.Sgf_game(9)
+        root = sgf_game.get_root()
+        root.add_comment_text("hello\nworld")
+        self.assertEqual(root.get('C'), "hello\nworld")
+        root.add_comment_text("hello\naga]in")
+        self.assertEqual(root.get('C'), "hello\nworld\n\nhello\naga]in")

--- a/tests/gosgf/sgf_test.py
+++ b/tests/gosgf/sgf_test.py
@@ -524,7 +524,7 @@ class SgfTestCase(unittest.TestCase):
             b"(;FF[4]CA[UTF-8]GM[1]SZ[9];N[e0];N[e1];N[e2];N[e3];N[e4];N[e5])\n")
         g2 = gosgf.Sgf_game.from_string(b"(;SZ[9](;N[n1];N[n3])(;N[n2]))")
         for i in range(6):
-            g2.extend_main_sequence().set(b"N", b"e%d" % i)
+            g2.extend_main_sequence().set(b"N", ("e%d" % i).encode('ascii'))
         self.assertEqual(
             g2.serialise(),
             b"(;SZ[9](;N[n1];N[n3];N[e0];N[e1];N[e2];N[e3];N[e4];N[e5])(;N[n2]))\n")

--- a/tests/gosgf/sgf_test.py
+++ b/tests/gosgf/sgf_test.py
@@ -518,7 +518,7 @@ class SgfTestCase(unittest.TestCase):
     def test_extend_main_sequence(self):
         g1 = gosgf.Sgf_game(9)
         for i in range(6):
-            g1.extend_main_sequence().set(b"N", b"e%d" % i)
+            g1.extend_main_sequence().set(b"N", ("e%d" % i).encode('ascii'))
         self.assertEqual(
             g1.serialise(),
             b"(;FF[4]CA[UTF-8]GM[1]SZ[9];N[e0];N[e1];N[e2];N[e3];N[e4];N[e5])\n")

--- a/tests/gosgf/sgf_test.py
+++ b/tests/gosgf/sgf_test.py
@@ -6,13 +6,13 @@ from textwrap import dedent
 
 from betago import gosgf
 
-SAMPLE_SGF = """\
+SAMPLE_SGF = b"""\
 (;AP[testsuite:0]CA[utf-8]DT[2009-06-06]FF[4]GM[1]KM[7.5]PB[Black engine]
 PL[B]PW[White engine]RE[W+R]SZ[9]AB[ai][bh][ee]AW[fc][gc];B[dg];W[ef]C[comment
 on two lines];B[];W[tt]C[Final comment])
 """
 
-SAMPLE_SGF_VAR = """\
+SAMPLE_SGF_VAR = b"""\
 (;AP[testsuite:0]CA[utf-8]DT[2009-06-06]FF[4]GM[1]KM[7.5]PB[Black engine]
 PL[B]RE[W+R]SZ[9]AB[ai][bh][ee]AW[fd][gc]VW[]
 ;B[dg]
@@ -33,14 +33,14 @@ class SgfTestCase(unittest.TestCase):
         g1 = gosgf.Sgf_game(9)
         self.assertEqual(g1.get_size(), 9)
         root = g1.get_root()
-        self.assertEqual(root.get_raw('FF'), '4')
-        self.assertEqual(root.get_raw('GM'), '1')
-        self.assertEqual(root.get_raw('SZ'), '9')
+        self.assertEqual(root.get_raw(b'FF'), b'4')
+        self.assertEqual(root.get_raw(b'GM'), b'1')
+        self.assertEqual(root.get_raw(b'SZ'), b'9')
         self.assertEqual(root.get_raw_property_map(), {
-            'FF': ['4'],
-            'GM': ['1'],
-            'SZ': ['9'],
-            'CA': ['UTF-8'],
+            b'FF': [b'4'],
+            b'GM': [b'1'],
+            b'SZ': [b'9'],
+            b'CA': [b'UTF-8'],
             });
         self.assertEqual(list(root), [])
         self.assertEqual(root.parent, None)
@@ -50,7 +50,7 @@ class SgfTestCase(unittest.TestCase):
         class Namespace(object):
             pass
         coarse_game = Namespace()
-        coarse_game.sequence = [{'SZ' : ["9"]}, {'B' : ["aa"]}]
+        coarse_game.sequence = [{b'SZ' : [b"9"]}, {b'B' : [b"aa"]}]
         coarse_game.children = []
         g1 = gosgf.Sgf_game.from_coarse_game_tree(coarse_game)
         self.assertEqual(g1.get_size(), 9)
@@ -61,53 +61,53 @@ class SgfTestCase(unittest.TestCase):
         self.assertEqual(len(root), 1)
 
         coarse_game2 = Namespace()
-        coarse_game2.sequence = [{'SZ' : ["0"]}, {'B' : ["aa"]}]
+        coarse_game2.sequence = [{b'SZ' : [b"0"]}, {b'B' : [b"aa"]}]
         coarse_game2.children = []
         self.assertRaisesRegexp(ValueError, "size out of range: 0",
                                 gosgf.Sgf_game.from_coarse_game_tree, coarse_game2)
 
     def test_sgf_game_from_string(self):
-        g1 = gosgf.Sgf_game.from_string("(;)")
+        g1 = gosgf.Sgf_game.from_string(b"(;)")
         self.assertEqual(g1.get_size(), 19)
         self.assertRaisesRegexp(ValueError, "unexpected end of SGF data",
-                                gosgf.Sgf_game.from_string, "(;SZ[9]")
-        g2 = gosgf.Sgf_game.from_string("(;SZ[9])")
+                                gosgf.Sgf_game.from_string, b"(;SZ[9]")
+        g2 = gosgf.Sgf_game.from_string(b"(;SZ[9])")
         self.assertEqual(g2.get_size(), 9)
-        self.assertRaisesRegexp(ValueError, "bad SZ property: a",
-                                gosgf.Sgf_game.from_string, "(;SZ[a])")
-        self.assertRaisesRegexp(ValueError, "size out of range: 27",
-                              gosgf.Sgf_game.from_string, "(;SZ[27])")
-        self.assertRaisesRegexp(ValueError, "unknown encoding: $",
-                              gosgf.Sgf_game.from_string, "(;CA[])")
-    
+        self.assertRaisesRegexp(ValueError, "bad SZ property",
+                                gosgf.Sgf_game.from_string, b"(;SZ[a])")
+        self.assertRaisesRegexp(ValueError, "size out of range",
+                                gosgf.Sgf_game.from_string, b"(;SZ[27])")
+        self.assertRaisesRegexp(ValueError, "unknown encoding",
+                                gosgf.Sgf_game.from_string, b"(;CA[])")
+
     def test_node(self):
         sgf_game = gosgf.Sgf_game.from_string(
-            r"(;KM[6.5]C[sample\: comment]AB[ai][bh][ee]AE[];B[dg])")
+            r"(;KM[6.5]C[sample\: comment]AB[ai][bh][ee]AE[];B[dg])".encode('ascii'))
         node0 = sgf_game.get_root()
         node1 = list(sgf_game.main_sequence_iter())[1]
         self.assertEqual(node0.get_size(), 19)
         self.assertEqual(node0.get_encoding(), "ISO-8859-1")
-        self.assertIs(node0.has_property('KM'), True)
-        self.assertIs(node0.has_property('XX'), False)
-        self.assertIs(node1.has_property('KM'), False)
-        self.assertEqual(set(node0.properties()), set(["KM", "C", "AB", "AE"]))
-        self.assertEqual(set(node1.properties()), set(["B"]))
-        self.assertEqual(node0.get_raw('C'), r"sample\: comment")
-        self.assertEqual(node0.get_raw('AB'), "ai")
-        self.assertEqual(node0.get_raw('AE'), "")
-        self.assertRaises(KeyError, node0.get_raw, 'XX')
-        self.assertEqual(node0.get_raw_list('KM'), ['6.5'])
-        self.assertEqual(node0.get_raw_list('AB'), ['ai', 'bh', 'ee'])
-        self.assertEqual(node0.get_raw_list('AE'), [''])
-        self.assertRaises(KeyError, node0.get_raw_list, 'XX')
-        self.assertRaises(KeyError, node0.get_raw, 'XX')
-    
+        self.assertIs(node0.has_property(b'KM'), True)
+        self.assertIs(node0.has_property(b'XX'), False)
+        self.assertIs(node1.has_property(b'KM'), False)
+        self.assertEqual(set(node0.properties()), set([b"KM", b"C", b"AB", b"AE"]))
+        self.assertEqual(set(node1.properties()), set([b"B"]))
+        self.assertEqual(node0.get_raw(b'C'), r"sample\: comment".encode('ascii'))
+        self.assertEqual(node0.get_raw(b'AB'), b"ai")
+        self.assertEqual(node0.get_raw(b'AE'), b"")
+        self.assertRaises(KeyError, node0.get_raw, b'XX')
+        self.assertEqual(node0.get_raw_list(b'KM'), [b'6.5'])
+        self.assertEqual(node0.get_raw_list(b'AB'), [b'ai', b'bh', b'ee'])
+        self.assertEqual(node0.get_raw_list(b'AE'), [b''])
+        self.assertRaises(KeyError, node0.get_raw_list, b'XX')
+        self.assertRaises(KeyError, node0.get_raw, b'XX')
+
     def test_property_combination(self):
-        sgf_game = gosgf.Sgf_game.from_string("(;XX[1]YY[2]XX[3]YY[4])")
+        sgf_game = gosgf.Sgf_game.from_string(b"(;XX[1]YY[2]XX[3]YY[4])")
         node0 = sgf_game.get_root()
-        self.assertEqual(node0.get_raw_list("XX"), ["1", "3"])
-        self.assertEqual(node0.get_raw_list("YY"), ["2", "4"])
-    
+        self.assertEqual(node0.get_raw_list(b"XX"), [b"1", b"3"])
+        self.assertEqual(node0.get_raw_list(b"YY"), [b"2", b"4"])
+
     def test_node_get(self):
         sgf_game = gosgf.Sgf_game.from_string(dedent(r"""
         (;AP[testsuite:0]CA[utf-8]DT[2009-06-06]FF[4]GM[1]KM[7.5]PB[Black engine]
@@ -120,36 +120,36 @@ class SgfTestCase(unittest.TestCase):
         sense]
         ;B[dg]KO[]AR[ab:cd][de:fg]FG[515:first move]
         LB[ac:lbl][bc:lbl2])
-        """))
+        """).encode('utf-8'))
         root = sgf_game.get_root()
         node1 = list(sgf_game.main_sequence_iter())[1]
-        self.assertRaises(KeyError, root.get, 'XX')
-        self.assertEqual(root.get('C'), "123:)\nabc")          # Text
-        self.assertEqual(root.get('EV'), "Test event")         # Simpletext
-        self.assertEqual(root.get('BM'), 2)                    # Double
-        self.assertEqual(root.get('YY'), "none\nsense")        # unknown (Text)
-        self.assertIs(node1.get('KO'), True)                   # None
-        self.assertEqual(root.get('KM'), 7.5)                  # Real
-        self.assertEqual(root.get('GM'), 1)                    # Number
-        self.assertEqual(root.get('PL'), 'b')                  # Color
-        self.assertEqual(node1.get('B'), (2, 3))               # Point
-        self.assertEqual(root.get('AB'),
-                       set([(0, 0), (1, 1), (4, 4)]))        # List of Point
-        self.assertEqual(root.get('VW'), set())                # Empty elist
-        self.assertEqual(root.get('AP'), ("testsuite", "0"))   # Application
-        self.assertEqual(node1.get('AR'),
-                       [((7, 0), (5, 2)), ((4, 3), (2, 5))]) # Arrow
-        self.assertEqual(node1.get('FG'), (515, "first move")) # Figure
-        self.assertEqual(node1.get('LB'),
-                       [((6, 0), "lbl"), ((6, 1), "lbl2")])  # Label
+        self.assertRaises(KeyError, root.get, b'XX')
+        self.assertEqual(root.get(b'C'), b"123:)\nabc")          # Text
+        self.assertEqual(root.get(b'EV'), b"Test event")         # Simpletext
+        self.assertEqual(root.get(b'BM'), 2)                    # Double
+        self.assertEqual(root.get(b'YY'), b"none\nsense")        # unknown (Text)
+        self.assertIs(node1.get(b'KO'), True)                   # None
+        self.assertEqual(root.get(b'KM'), 7.5)                  # Real
+        self.assertEqual(root.get(b'GM'), 1)                    # Number
+        self.assertEqual(root.get(b'PL'), 'b')                  # Color
+        self.assertEqual(node1.get(b'B'), (2, 3))               # Point
+        self.assertEqual(root.get(b'AB'),
+                         set([(0, 0), (1, 1), (4, 4)]))        # List of Point
+        self.assertEqual(root.get(b'VW'), set())                # Empty elist
+        self.assertEqual(root.get(b'AP'), (b"testsuite", b"0"))   # Application
+        self.assertEqual(node1.get(b'AR'),
+                         [((7, 0), (5, 2)), ((4, 3), (2, 5))]) # Arrow
+        self.assertEqual(node1.get(b'FG'), (515, b"first move")) # Figure
+        self.assertEqual(node1.get(b'LB'),
+                         [((6, 0), b"lbl"), ((6, 1), b"lbl2")])  # Label
         # Check we (leniently) treat lists like elists on read
-        self.assertEqual(root.get('AE'), set())
-        self.assertRaisesRegexp(ValueError, "multiple values", root.get, 'PW')
-    
+        self.assertEqual(root.get(b'AE'), set())
+        self.assertRaisesRegexp(ValueError, "multiple values", root.get, b'PW')
+
     def test_text_values(self):
         def check(s):
-            sgf_game = gosgf.Sgf_game.from_string(s)
-            return sgf_game.get_root().get("C")
+            sgf_game = gosgf.Sgf_game.from_string(s.encode('ascii'))
+            return sgf_game.get_root().get(b"C").decode('ascii')
         # Round-trip check of Text values through tokeniser, parser, and
         # text_value().
         self.assertEqual(check(r"(;C[abc]KO[])"), r"abc")
@@ -162,8 +162,6 @@ class SgfTestCase(unittest.TestCase):
         self.assertEqual(check(r"(;C[xxx :\) yyy]KO[])"), r"xxx :) yyy")
         self.assertEqual(check("(;C[ab\\\nc])"), "abc")
         self.assertEqual(check("(;C[ab\nc])"), "ab\nc")
-
-
 
     def test_node_string(self):
         sgf_game = gosgf.Sgf_game.from_string(SAMPLE_SGF)
@@ -195,7 +193,7 @@ class SgfTestCase(unittest.TestCase):
 
     def test_node_get_setup_stones(self):
         sgf_game = gosgf.Sgf_game.from_string(
-            r"(;KM[6.5]SZ[9]C[sample\: comment]AB[ai][bh][ee]AE[bb];B[dg])")
+            r"(;KM[6.5]SZ[9]C[sample\: comment]AB[ai][bh][ee]AE[bb];B[dg])".encode('utf-8'))
         node0 = sgf_game.get_root()
         node1 = list(sgf_game.main_sequence_iter())[1]
         self.assertIs(node0.has_setup_stones(), True)
@@ -214,10 +212,10 @@ class SgfTestCase(unittest.TestCase):
         self.assertEqual(sgf_game.get_player_name('b'), "Black engine")
         self.assertIs(sgf_game.get_player_name('w'), None)
         self.assertEqual(sgf_game.get_winner(), 'w')
-        self.assertEqual(nodes[2].get('C'), "comment\non two lines")
-        self.assertEqual(nodes[4].get('C'), "Nonfinal comment")
+        self.assertEqual(nodes[2].get(b'C'), b"comment\non two lines")
+        self.assertEqual(nodes[4].get(b'C'), b"Nonfinal comment")
 
-        g2 = gosgf.Sgf_game.from_string("(;)")
+        g2 = gosgf.Sgf_game.from_string(b"(;)")
         self.assertEqual(g2.get_size(), 19)
         self.assertEqual(g2.get_komi(), 0.0)
         self.assertIs(g2.get_handicap(), None)
@@ -232,7 +230,7 @@ class SgfTestCase(unittest.TestCase):
         self.assertIs(root.parent, None)
         self.assertIs(root.owner, sgf_game)
         self.assertEqual(len(root), 1)
-        self.assertEqual(root[0].get_raw('B'), "dg")
+        self.assertEqual(root[0].get_raw(b'B'), b"dg")
         self.assertTrue(root)
         self.assertEqual(root.index(root[0]), 0)
 
@@ -247,8 +245,8 @@ class SgfTestCase(unittest.TestCase):
                        [branchnode[0], branchnode[1]])
         with self.assertRaises(IndexError):
             branchnode[2]
-        self.assertEqual(branchnode[0].get_raw('B'), "ia")
-        self.assertEqual(branchnode[1].get_raw('B'), "ib")
+        self.assertEqual(branchnode[0].get_raw(b'B'), b"ia")
+        self.assertEqual(branchnode[1].get_raw(b'B'), b"ib")
         self.assertEqual(branchnode.index(branchnode[0]), 0)
         self.assertEqual(branchnode.index(branchnode[1]), 1)
 
@@ -264,7 +262,7 @@ class SgfTestCase(unittest.TestCase):
         # check nothing breaks when first retrieval is by index
         game2 = gosgf.Sgf_game.from_string(SAMPLE_SGF)
         root2 = game2.get_root()
-        self.assertEqual(root2[0].get_raw('B'), "dg")
+        self.assertEqual(root2[0].get_raw(b'B'), b"dg")
 
     def test_serialise(self):
         # Doesn't cover transcoding
@@ -276,10 +274,10 @@ class SgfTestCase(unittest.TestCase):
         on two lines]W[ef]
         ;B[];C[Nonfinal comment]VW[aa:bb](;B[ia];W[ib];B[ic])(;B[ib];W[ic](;B[id])(;
         B[ie])))
-        """))
+        """).encode('utf-8'))
         sgf_game2 = gosgf.Sgf_game.from_string(serialised)
-        self.assertEqual(map(str, sgf_game.get_main_sequence()),
-                         map(str, sgf_game2.get_main_sequence()))
+        self.assertEqual([str(x) for x in sgf_game.get_main_sequence()],
+                         [str(x) for x in sgf_game2.get_main_sequence()])
 
     def test_serialise_wrap(self):
         sgf_game = gosgf.Sgf_game.from_string(SAMPLE_SGF_VAR)
@@ -287,203 +285,197 @@ class SgfTestCase(unittest.TestCase):
         self.assertEqual(serialised, dedent("""\
         (;FF[4]AB[ai][bh][ee]AP[testsuite:0]AW[fd][gc]CA[utf-8]DT[2009-06-06]GM[1]KM[7.5]PB[Black engine]PL[B]RE[W+R]SZ[9]VW[];B[dg];C[comment
         on two lines]W[ef];B[];C[Nonfinal comment]VW[aa:bb](;B[ia];W[ib];B[ic])(;B[ib];W[ic](;B[id])(;B[ie])))
-        """))
+        """).encode('ascii'))
         sgf_game2 = gosgf.Sgf_game.from_string(serialised)
-        self.assertEqual(map(str, sgf_game.get_main_sequence()),
-                         map(str, sgf_game2.get_main_sequence()))
+        seq1 = [str(x) for x in sgf_game.get_main_sequence()]
+        seq2 = [str(x) for x in sgf_game2.get_main_sequence()]
+        self.assertEqual(seq1, seq2)
 
     def test_encoding(self):
         g1 = gosgf.Sgf_game(19)
         self.assertEqual(g1.get_charset(), "UTF-8")
         root = g1.get_root()
         self.assertEqual(root.get_encoding(), "UTF-8")
-        root.set("C", "£")
-        self.assertEqual(root.get("C"), "£")
-        self.assertEqual(root.get_raw("C"), "£")
+        root.set(b"C", "£".encode('utf-8'))
+        self.assertEqual(root.get(b"C"), "£".encode('utf-8'))
+        self.assertEqual(root.get_raw(b"C"), "£".encode('utf-8'))
         self.assertEqual(g1.serialise(), dedent("""\
         (;FF[4]C[£]CA[UTF-8]GM[1]SZ[19])
-        """))
-    
+        """).encode('utf-8'))
+
         g2 = gosgf.Sgf_game(19, encoding="iso-8859-1")
         self.assertEqual(g2.get_charset(), "ISO-8859-1")
         root = g2.get_root()
         self.assertEqual(root.get_encoding(), "ISO-8859-1")
-        root.set("C", "£")
-        self.assertEqual(root.get("C"), "£")
-        self.assertEqual(root.get_raw("C"), "\xa3")
-        self.assertEqual(g2.serialise(), dedent("""\
-        (;FF[4]C[\xa3]CA[ISO-8859-1]GM[1]SZ[19])
-        """))
-    
-        self.assertRaisesRegexp(ValueError, "unknown encoding: unknownencoding",
-                              gosgf.Sgf_game, 19, "unknownencoding")
-    
-    
+        root.set(b"C", "£".encode('utf-8'))
+        self.assertEqual(root.get(b"C"), "£".encode('utf-8'))
+        self.assertEqual(root.get_raw(b"C"), b"\xa3")
+        self.assertEqual(g2.serialise(), b"(;FF[4]C[\xa3]CA[ISO-8859-1]GM[1]SZ[19])\n")
+
+        self.assertRaisesRegexp(ValueError, "unknown encoding",
+                                gosgf.Sgf_game, 19, "unknownencoding")
+
     def test_loaded_sgf_game_encoding(self):
         g1 = gosgf.Sgf_game.from_string("""
         (;FF[4]C[£]CA[utf-8]GM[1]SZ[19])
-        """)
+        """.encode('utf-8'))
         self.assertEqual(g1.get_charset(), "UTF-8")
         root = g1.get_root()
         self.assertEqual(root.get_encoding(), "UTF-8")
-        self.assertEqual(root.get("C"), "£")
-        self.assertEqual(root.get_raw("C"), "£")
+        self.assertEqual(root.get(b"C"), "£".encode('utf-8'))
+        self.assertEqual(root.get_raw(b"C"), "£".encode('utf-8'))
         self.assertEqual(g1.serialise(), dedent("""\
         (;FF[4]C[£]CA[utf-8]GM[1]SZ[19])
-        """))
-    
-        g2 = gosgf.Sgf_game.from_string("""
+        """).encode('utf-8'))
+
+        g2 = gosgf.Sgf_game.from_string(b"""
         (;FF[4]C[\xa3]CA[iso-8859-1]GM[1]SZ[19])
         """)
         self.assertEqual(g2.get_charset(), "ISO-8859-1")
         root = g2.get_root()
         self.assertEqual(root.get_encoding(), "ISO-8859-1")
-        self.assertEqual(root.get("C"), "£")
-        self.assertEqual(root.get_raw("C"), "\xa3")
+        self.assertEqual(root.get(b"C"), "£".encode('utf-8'))
+        self.assertEqual(root.get_raw(b"C"), b"\xa3")
         self.assertEqual(g2.serialise(), dedent("""\
-        (;FF[4]C[\xa3]CA[iso-8859-1]GM[1]SZ[19])
-        """))
-    
-        g3 = gosgf.Sgf_game.from_string("""
+        (;FF[4]C[£]CA[iso-8859-1]GM[1]SZ[19])
+        """).encode('iso-8859-1'))
+
+        g3 = gosgf.Sgf_game.from_string(b"""
         (;FF[4]C[\xa3]GM[1]SZ[19])
         """)
         self.assertEqual(g3.get_charset(), "ISO-8859-1")
         root = g3.get_root()
         self.assertEqual(root.get_encoding(), "ISO-8859-1")
-        self.assertEqual(root.get("C"), "£")
-        self.assertEqual(root.get_raw("C"), "\xa3")
+        self.assertEqual(root.get(b"C"), "£".encode('utf-8'))
+        self.assertEqual(root.get_raw(b"C"), b"\xa3")
         self.assertEqual(g3.serialise(), dedent("""\
-        (;FF[4]C[\xa3]GM[1]SZ[19])
-        """))
-    
+        (;FF[4]C[£]GM[1]SZ[19])
+        """).encode('iso-8859-1'))
+
         # This is invalidly encoded. get() notices, but serialise() doesn't care.
-        g4 = gosgf.Sgf_game.from_string("""
+        g4 = gosgf.Sgf_game.from_string(b"""
         (;FF[4]C[\xa3]CA[utf-8]GM[1]SZ[19])
         """)
         self.assertEqual(g4.get_charset(), "UTF-8")
         root = g4.get_root()
         self.assertEqual(root.get_encoding(), "UTF-8")
-        self.assertRaises(UnicodeDecodeError, root.get, "C")
-        self.assertEqual(root.get_raw("C"), "\xa3")
-        self.assertEqual(g4.serialise(), dedent("""\
-        (;FF[4]C[\xa3]CA[utf-8]GM[1]SZ[19])
-        """))
-    
+        self.assertRaises(UnicodeDecodeError, root.get, b"C")
+        self.assertEqual(root.get_raw(b"C"), b"\xa3")
+        self.assertEqual(g4.serialise(), b"""(;FF[4]C[\xa3]CA[utf-8]GM[1]SZ[19])\n""")
+
         self.assertRaisesRegexp(
-            ValueError, "unknown encoding: unknownencoding",
-            gosgf.Sgf_game.from_string, """
+            ValueError, "unknown encoding",
+            gosgf.Sgf_game.from_string, b"""
             (;FF[4]CA[unknownencoding]GM[1]SZ[19])
             """)
-    
+
     def test_override_encoding(self):
         g1 = gosgf.Sgf_game.from_string("""
         (;FF[4]C[£]CA[iso-8859-1]GM[1]SZ[19])
-        """, override_encoding="utf-8")
+        """.encode('utf-8'), override_encoding="utf-8")
         root = g1.get_root()
         self.assertEqual(root.get_encoding(), "UTF-8")
-        self.assertEqual(root.get("C"), "£")
-        self.assertEqual(root.get_raw("C"), "£")
+        self.assertEqual(root.get(b"C"), "£".encode('utf-8'))
+        self.assertEqual(root.get_raw(b"C"), "£".encode('utf-8'))
         self.assertEqual(g1.serialise(), dedent("""\
         (;FF[4]C[£]CA[UTF-8]GM[1]SZ[19])
-        """))
-    
-        g2 = gosgf.Sgf_game.from_string("""
+        """).encode('utf-8'))
+
+        g2 = gosgf.Sgf_game.from_string(b"""
         (;FF[4]C[\xa3]CA[utf-8]GM[1]SZ[19])
         """, override_encoding="iso-8859-1")
         root = g2.get_root()
         self.assertEqual(root.get_encoding(), "ISO-8859-1")
-        self.assertEqual(root.get("C"), "£")
-        self.assertEqual(root.get_raw("C"), "\xa3")
-        self.assertEqual(g2.serialise(), dedent("""\
-        (;FF[4]C[\xa3]CA[ISO-8859-1]GM[1]SZ[19])
-        """))
-    
+        self.assertEqual(root.get(b"C"), "£".encode('utf-8'))
+        self.assertEqual(root.get_raw(b"C"), b'\xa3')
+        self.assertEqual(g2.serialise().strip(), b"""(;FF[4]C[\xa3]CA[ISO-8859-1]GM[1]SZ[19])""")
+
     def test_serialise_transcoding(self):
         g1 = gosgf.Sgf_game.from_string("""
         (;FF[4]C[£]CA[utf-8]GM[1]SZ[19])
-        """)
+        """.encode('utf-8'))
         self.assertEqual(g1.serialise(), dedent("""\
         (;FF[4]C[£]CA[utf-8]GM[1]SZ[19])
-        """))
-        g1.get_root().set("CA", "latin-1")
+        """).encode('utf-8'))
+        g1.get_root().set(b"CA", b"latin-1")
         self.assertEqual(g1.serialise(), dedent("""\
-        (;FF[4]C[\xa3]CA[latin-1]GM[1]SZ[19])
-        """))
-        g1.get_root().set("CA", "unknown")
-        self.assertRaisesRegexp(ValueError, "unsupported charset: \['unknown']",
-                              g1.serialise)
-    
+        (;FF[4]C[£]CA[latin-1]GM[1]SZ[19])
+        """).encode('latin-1'))
+        g1.get_root().set(b"CA", b"unknown")
+        self.assertRaisesRegexp(ValueError, "unsupported charset",
+                                g1.serialise)
+
         # improperly-encoded from the start
         g2 = gosgf.Sgf_game.from_string("""
         (;FF[4]C[£]CA[ascii]GM[1]SZ[19])
-        """)
+        """.encode('utf-8'))
         self.assertEqual(g2.serialise(), dedent("""\
         (;FF[4]C[£]CA[ascii]GM[1]SZ[19])
-        """))
-        g2.get_root().set("CA", "utf-8")
+        """).encode('utf-8'))
+        g2.get_root().set(b"CA", b"utf-8")
         self.assertRaises(UnicodeDecodeError, g2.serialise)
-    
+
         g3 = gosgf.Sgf_game.from_string("""
         (;FF[4]C[Δ]CA[utf-8]GM[1]SZ[19])
-        """)
-        g3.get_root().unset("CA")
+        """.encode('utf-8'))
+        g3.get_root().unset(b"CA")
         self.assertRaises(UnicodeEncodeError, g3.serialise)
-    
+
     def test_tree_mutation(self):
         sgf_game = gosgf.Sgf_game(9)
         root = sgf_game.get_root()
         n1 = root.new_child()
-        n1.set("N", "n1")
+        n1.set(b"N", b"n1")
         n2 = root.new_child()
-        n2.set("N", "n2")
+        n2.set(b"N", b"n2")
         n3 = n1.new_child()
-        n3.set("N", "n3")
+        n3.set(b"N", b"n3")
         n4 = root.new_child(1)
-        n4.set("N", "n4")
+        n4.set(b"N", b"n4")
         self.assertEqual(
             sgf_game.serialise(),
-            "(;FF[4]CA[UTF-8]GM[1]SZ[9](;N[n1];N[n3])(;N[n4])(;N[n2]))\n")
+            b"(;FF[4]CA[UTF-8]GM[1]SZ[9](;N[n1];N[n3])(;N[n4])(;N[n2]))\n")
         self.assertEqual(
             [node.get_raw_property_map() for node in sgf_game.main_sequence_iter()],
-            [node.get_raw_property_map() for node in root, root[0], n3])
+            [node.get_raw_property_map() for node in (root, root[0], n3)])
         self.assertIs(sgf_game.get_last_node(), n3)
-    
+
         n1.delete()
         self.assertEqual(
             sgf_game.serialise(),
-            "(;FF[4]CA[UTF-8]GM[1]SZ[9](;N[n4])(;N[n2]))\n")
+            b"(;FF[4]CA[UTF-8]GM[1]SZ[9](;N[n4])(;N[n2]))\n")
         self.assertRaises(ValueError, root.delete)
-    
+
     def test_tree_mutation_from_coarse_game(self):
-        sgf_game = gosgf.Sgf_game.from_string("(;SZ[9](;N[n1];N[n3])(;N[n2]))")
+        sgf_game = gosgf.Sgf_game.from_string(b"(;SZ[9](;N[n1];N[n3])(;N[n2]))")
         root = sgf_game.get_root()
         n4 = root.new_child()
-        n4.set("N", "n4")
+        n4.set(b"N", b"n4")
         n3 = root[0][0]
-        self.assertEqual(n3.get("N"), "n3")
+        self.assertEqual(n3.get(b"N"), b"n3")
         n5 = n3.new_child()
-        n5.set("N", "n5")
+        n5.set(b"N", b"n5")
         self.assertEqual(sgf_game.serialise(),
-                       "(;SZ[9](;N[n1];N[n3];N[n5])(;N[n2])(;N[n4]))\n")
+                         b"(;SZ[9](;N[n1];N[n3];N[n5])(;N[n2])(;N[n4]))\n")
         self.assertEqual(
             [node.get_raw_property_map() for node in sgf_game.main_sequence_iter()],
-            [node.get_raw_property_map() for node in root, root[0], n3, n5])
+            [node.get_raw_property_map() for node in (root, root[0], n3, n5)])
         self.assertIs(sgf_game.get_last_node(), n5)
         n3.delete()
         self.assertEqual(sgf_game.serialise(),
-                       "(;SZ[9](;N[n1])(;N[n2])(;N[n4]))\n")
+                         b"(;SZ[9](;N[n1])(;N[n2])(;N[n4]))\n")
         self.assertRaises(ValueError, root.delete)
-    
+
     def test_tree_new_child_with_unexpanded_root_and_index(self):
-        sgf_game = gosgf.Sgf_game.from_string("(;SZ[9](;N[n1];N[n3])(;N[n2]))")
+        sgf_game = gosgf.Sgf_game.from_string(b"(;SZ[9](;N[n1];N[n3])(;N[n2]))")
         root = sgf_game.get_root()
         n4 = root.new_child(2)
-        n4.set("N", "n4")
+        n4.set(b"N", b"n4")
         self.assertEqual(sgf_game.serialise(),
-                       "(;SZ[9](;N[n1];N[n3])(;N[n2])(;N[n4]))\n")
-    
+                         b"(;SZ[9](;N[n1];N[n3])(;N[n2])(;N[n4]))\n")
+
     def test_reparent(self):
-        g1 = gosgf.Sgf_game.from_string("(;SZ[9](;N[n1];N[n3])(;N[n2]))")
+        g1 = gosgf.Sgf_game.from_string(b"(;SZ[9](;N[n1];N[n3])(;N[n2]))")
         root = g1.get_root()
         # Test with unexpanded root
         self.assertRaisesRegexp(ValueError, "would create a loop",
@@ -491,51 +483,51 @@ class SgfTestCase(unittest.TestCase):
         n1 = root[0]
         n2 = root[1]
         n3 = root[0][0]
-        self.assertEqual(n1.get("N"), "n1")
-        self.assertEqual(n2.get("N"), "n2")
-        self.assertEqual(n3.get("N"), "n3")
+        self.assertEqual(n1.get(b"N"), b"n1")
+        self.assertEqual(n2.get(b"N"), b"n2")
+        self.assertEqual(n3.get(b"N"), b"n3")
         n3.reparent(n2)
-        self.assertEqual(g1.serialise(), "(;SZ[9](;N[n1])(;N[n2];N[n3]))\n")
+        self.assertEqual(g1.serialise(), b"(;SZ[9](;N[n1])(;N[n2];N[n3]))\n")
         n3.reparent(n2)
-        self.assertEqual(g1.serialise(), "(;SZ[9](;N[n1])(;N[n2];N[n3]))\n")
+        self.assertEqual(g1.serialise(), b"(;SZ[9](;N[n1])(;N[n2];N[n3]))\n")
         self.assertRaisesRegexp(ValueError, "would create a loop",
-                              root.reparent, n3)
+                                root.reparent, n3)
         self.assertRaisesRegexp(ValueError, "would create a loop",
-                              n3.reparent, n3)
+                                n3.reparent, n3)
         g2 = gosgf.Sgf_game(9)
         self.assertRaisesRegexp(
             ValueError, "new parent doesn't belong to the same game",
             n3.reparent, g2.get_root())
-    
+
     def test_reparent_index(self):
-        g1 = gosgf.Sgf_game.from_string("(;SZ[9](;N[n1];N[n3])(;N[n2]))")
+        g1 = gosgf.Sgf_game.from_string(b"(;SZ[9](;N[n1];N[n3])(;N[n2]))")
         root = g1.get_root()
         n1 = root[0]
         n2 = root[1]
         n3 = root[0][0]
-        self.assertEqual(n1.get("N"), "n1")
-        self.assertEqual(n2.get("N"), "n2")
-        self.assertEqual(n3.get("N"), "n3")
+        self.assertEqual(n1.get(b"N"), b"n1")
+        self.assertEqual(n2.get(b"N"), b"n2")
+        self.assertEqual(n3.get(b"N"), b"n3")
         n3.reparent(root, index=1)
-        self.assertEqual(g1.serialise(), "(;SZ[9](;N[n1])(;N[n3])(;N[n2]))\n")
+        self.assertEqual(g1.serialise(), b"(;SZ[9](;N[n1])(;N[n3])(;N[n2]))\n")
         n3.reparent(root, index=1)
-        self.assertEqual(g1.serialise(), "(;SZ[9](;N[n1])(;N[n3])(;N[n2]))\n")
+        self.assertEqual(g1.serialise(), b"(;SZ[9](;N[n1])(;N[n3])(;N[n2]))\n")
         n3.reparent(root, index=2)
-        self.assertEqual(g1.serialise(), "(;SZ[9](;N[n1])(;N[n2])(;N[n3]))\n")
-    
+        self.assertEqual(g1.serialise(), b"(;SZ[9](;N[n1])(;N[n2])(;N[n3]))\n")
+
     def test_extend_main_sequence(self):
         g1 = gosgf.Sgf_game(9)
-        for i in xrange(6):
-            g1.extend_main_sequence().set("N", "e%d" % i)
+        for i in range(6):
+            g1.extend_main_sequence().set(b"N", b"e%d" % i)
         self.assertEqual(
             g1.serialise(),
-            "(;FF[4]CA[UTF-8]GM[1]SZ[9];N[e0];N[e1];N[e2];N[e3];N[e4];N[e5])\n")
-        g2 = gosgf.Sgf_game.from_string("(;SZ[9](;N[n1];N[n3])(;N[n2]))")
-        for i in xrange(6):
-            g2.extend_main_sequence().set("N", "e%d" % i)
+            b"(;FF[4]CA[UTF-8]GM[1]SZ[9];N[e0];N[e1];N[e2];N[e3];N[e4];N[e5])\n")
+        g2 = gosgf.Sgf_game.from_string(b"(;SZ[9](;N[n1];N[n3])(;N[n2]))")
+        for i in range(6):
+            g2.extend_main_sequence().set(b"N", b"e%d" % i)
         self.assertEqual(
             g2.serialise(),
-            "(;SZ[9](;N[n1];N[n3];N[e0];N[e1];N[e2];N[e3];N[e4];N[e5])(;N[n2]))\n")
+            b"(;SZ[9](;N[n1];N[n3];N[e0];N[e1];N[e2];N[e3];N[e4];N[e5])(;N[n2]))\n")
 
     def test_get_sequence_above(self):
         sgf_game = gosgf.Sgf_game.from_string(SAMPLE_SGF_VAR)
@@ -585,7 +577,7 @@ class SgfTestCase(unittest.TestCase):
         # (Have to call this before making the tree expand.)
         with self.assertRaises(AttributeError):
             nodes[1].parent
-    
+
         tree_nodes = sgf_game.get_main_sequence()
         self.assertEqual(len(tree_nodes), 8)
         self.assertIs(root.get_raw_property_map(),
@@ -607,25 +599,25 @@ class SgfTestCase(unittest.TestCase):
         branchnode = root[0][0][0][0]
         leaf = branchnode[1][0][1]
 
-        self.assertEqual(root.get("VW"), set())
-        self.assertIs(root.find("VW"), root)
-        self.assertRaises(KeyError, root[0].get, "VW")
-        self.assertEqual(root[0].find_property("VW"), set())
-        self.assertIs(root[0].find("VW"), root)
+        self.assertEqual(root.get(b"VW"), set())
+        self.assertIs(root.find(b"VW"), root)
+        self.assertRaises(KeyError, root[0].get, b"VW")
+        self.assertEqual(root[0].find_property(b"VW"), set())
+        self.assertIs(root[0].find(b"VW"), root)
 
-        self.assertEqual(branchnode.get("VW"),
-                       set([(7, 0), (7, 1), (8, 0), (8, 1)]))
-        self.assertIs(branchnode.find("VW"), branchnode)
-        self.assertEqual(branchnode.find_property("VW"),
-                       set([(7, 0), (7, 1), (8, 0), (8, 1)]))
+        self.assertEqual(branchnode.get(b"VW"),
+                         set([(7, 0), (7, 1), (8, 0), (8, 1)]))
+        self.assertIs(branchnode.find(b"VW"), branchnode)
+        self.assertEqual(branchnode.find_property(b"VW"),
+                         set([(7, 0), (7, 1), (8, 0), (8, 1)]))
 
-        self.assertRaises(KeyError, leaf.get, "VW")
-        self.assertIs(leaf.find("VW"), branchnode)
-        self.assertEqual(leaf.find_property("VW"),
-                       set([(7, 0), (7, 1), (8, 0), (8, 1)]))
+        self.assertRaises(KeyError, leaf.get, b"VW")
+        self.assertIs(leaf.find(b"VW"), branchnode)
+        self.assertEqual(leaf.find_property(b"VW"),
+                         set([(7, 0), (7, 1), (8, 0), (8, 1)]))
 
-        self.assertIs(leaf.find("XX"), None)
-        self.assertRaises(KeyError, leaf.find_property, "XX")
+        self.assertIs(leaf.find(b"XX"), None)
+        self.assertRaises(KeyError, leaf.find_property, b"XX")
 
     def test_node_set_raw(self):
         sgf_game = gosgf.Sgf_game.from_string(dedent(r"""
@@ -635,46 +627,46 @@ class SgfTestCase(unittest.TestCase):
         PL[B]
         C[123abc]
         ;B[dg]C[first move])
-        """))
+        """).encode('utf-8'))
         root = sgf_game.get_root()
-        self.assertEqual(root.get_raw('RE'), "W+R")
-        root.set_raw('RE', "W+2.5")
-        self.assertEqual(root.get_raw('RE'), "W+2.5")
-        self.assertRaises(KeyError, root.get_raw, 'XX')
-        root.set_raw('XX', "xyz")
-        self.assertEqual(root.get_raw('XX'), "xyz")
-    
-        root.set_raw_list('XX', ("abc", "def"))
-        self.assertEqual(root.get_raw('XX'), "abc")
-        self.assertEqual(root.get_raw_list('XX'), ["abc", "def"])
-    
+        self.assertEqual(root.get_raw(b'RE'), b"W+R")
+        root.set_raw(b'RE', b"W+2.5")
+        self.assertEqual(root.get_raw(b'RE'), b"W+2.5")
+        self.assertRaises(KeyError, root.get_raw, b'XX')
+        root.set_raw(b'XX', b"xyz")
+        self.assertEqual(root.get_raw(b'XX'), b"xyz")
+
+        root.set_raw_list(b'XX', (b"abc", b"def"))
+        self.assertEqual(root.get_raw(b'XX'), b"abc")
+        self.assertEqual(root.get_raw_list(b'XX'), [b"abc", b"def"])
+
         self.assertRaisesRegexp(ValueError, "empty property list",
-                              root.set_raw_list, 'B', [])
-    
-        values = ["123", "456"]
-        root.set_raw_list('YY', values)
-        self.assertEqual(root.get_raw_list('YY'), ["123", "456"])
-        values.append("789")
-        self.assertEqual(root.get_raw_list('YY'), ["123", "456"])
-    
+                              root.set_raw_list, b'B', [])
+
+        values = [b"123", b"456"]
+        root.set_raw_list(b'YY', values)
+        self.assertEqual(root.get_raw_list(b'YY'), [b"123", b"456"])
+        values.append(b"789")
+        self.assertEqual(root.get_raw_list(b'YY'), [b"123", b"456"])
+
         self.assertRaisesRegexp(ValueError, "ill-formed property identifier",
-                              root.set_raw, 'Black', "aa")
+                                root.set_raw, b'Black', b"aa")
         self.assertRaisesRegexp(ValueError, "ill-formed property identifier",
-                              root.set_raw_list, 'Black', ["aa"])
-    
-        root.set_raw('C', "foo\\]bar")
-        self.assertEqual(root.get_raw('C'), "foo\\]bar")
-        root.set_raw('C', "abc\\\\")
-        self.assertEqual(root.get_raw('C'), "abc\\\\")
+                                root.set_raw_list, b'Black', [b"aa"])
+
+        root.set_raw(b'C', b"foo\\]bar")
+        self.assertEqual(root.get_raw(b'C'), b"foo\\]bar")
+        root.set_raw(b'C', b"abc\\\\")
+        self.assertEqual(root.get_raw(b'C'), b"abc\\\\")
         self.assertRaisesRegexp(ValueError, "ill-formed raw property value",
-                              root.set_raw, 'C', "foo]bar")
+                                root.set_raw, b'C', b"foo]bar")
         self.assertRaisesRegexp(ValueError, "ill-formed raw property value",
-                              root.set_raw, 'C', "abc\\")
+                                root.set_raw, b'C', b"abc\\")
         self.assertRaisesRegexp(ValueError, "ill-formed raw property value",
-                              root.set_raw_list, 'C', ["abc", "de]f"])
-    
-        root.set_raw('C', "foo\\]bar\\\nbaz")
-        self.assertEqual(root.get('C'), "foo]barbaz")
+                                root.set_raw_list, b'C', [b"abc", b"de]f"])
+
+        root.set_raw(b'C', b"foo\\]bar\\\nbaz")
+        self.assertEqual(root.get(b'C'), b"foo]barbaz")
 
     def test_node_aliasing(self):
         # Check that node objects retrieved by different means use the same
@@ -682,7 +674,7 @@ class SgfTestCase(unittest.TestCase):
 
         sgf_game = gosgf.Sgf_game.from_string(dedent(r"""
         (;C[root];C[node 1])
-        """))
+        """).encode('utf-8'))
         root = sgf_game.get_root()
         plain_node = list(sgf_game.main_sequence_iter())[1]
         tree_node = root[0]
@@ -692,96 +684,96 @@ class SgfTestCase(unittest.TestCase):
         self.assertIs(tree_node.__class__, gosgf.Tree_node)
         self.assertIs(plain_node.__class__, gosgf.Node)
 
-        self.assertEqual(tree_node.get_raw('C'), "node 1")
-        tree_node.set_raw('C', r"test\value")
-        self.assertEqual(tree_node.get_raw('C'), r"test\value")
-        self.assertEqual(plain_node.get_raw('C'), r"test\value")
+        self.assertEqual(tree_node.get_raw(b'C'), b"node 1")
+        tree_node.set_raw(b'C', r"test\value".encode('ascii'))
+        self.assertEqual(tree_node.get_raw(b'C'), r"test\value".encode('ascii'))
+        self.assertEqual(plain_node.get_raw(b'C'), r"test\value".encode('ascii'))
 
-        plain_node.set_raw_list('XX', ["1", "2", "3"])
-        self.assertEqual(tree_node.get_raw_list('XX'), ["1", "2", "3"])
+        plain_node.set_raw_list(b'XX', [b"1", b"2", b"3"])
+        self.assertEqual(tree_node.get_raw_list(b'XX'), [b"1", b"2", b"3"])
 
     def test_node_set(self):
-        sgf_game = gosgf.Sgf_game.from_string("(;FF[4]GM[1]SZ[9])")
+        sgf_game = gosgf.Sgf_game.from_string(b"(;FF[4]GM[1]SZ[9])")
         root = sgf_game.get_root()
-        root.set("KO", True)
-        root.set("KM", 0.5)
-        root.set('DD', [(3, 4), (5, 6)])
-        root.set('AB', set([(0, 0), (1, 1), (4, 4)]))
-        root.set('TW', set())
-        root.set('XX', "nonsense [none]sense more n\\onsens\\e")
-    
+        root.set(b"KO", True)
+        root.set(b"KM", 0.5)
+        root.set(b'DD', [(3, 4), (5, 6)])
+        root.set(b'AB', set([(0, 0), (1, 1), (4, 4)]))
+        root.set(b'TW', set())
+        root.set(b'XX', b"nonsense [none]sense more n\\onsens\\e")
+
         self.assertEqual(sgf_game.serialise(), dedent("""\
         (;FF[4]AB[ai][bh][ee]DD[ef][gd]GM[1]KM[0.5]KO[]SZ[9]TW[]
         XX[nonsense [none\\]sense more n\\\\onsens\\\\e])
-        """))
-    
+        """).encode('utf-8'))
+
     def test_node_unset(self):
-        sgf_game = gosgf.Sgf_game.from_string("(;FF[4]GM[1]SZ[9]HA[3])")
+        sgf_game = gosgf.Sgf_game.from_string(b"(;FF[4]GM[1]SZ[9]HA[3])")
         root = sgf_game.get_root()
-        self.assertEqual(root.get('HA'), 3)
-        root.unset('HA')
-        self.assertRaises(KeyError, root.unset, 'PL')
+        self.assertEqual(root.get(b'HA'), 3)
+        root.unset(b'HA')
+        self.assertRaises(KeyError, root.unset, b'PL')
         self.assertEqual(sgf_game.serialise(),
-                       "(;FF[4]GM[1]SZ[9])\n")
-    
+                         b"(;FF[4]GM[1]SZ[9])\n")
+
     def test_set_and_unset_size(self):
-        g1 = gosgf.Sgf_game.from_string("(;FF[4]GM[1]SZ[9]HA[3])")
+        g1 = gosgf.Sgf_game.from_string(b"(;FF[4]GM[1]SZ[9]HA[3])")
         root1 = g1.get_root()
         self.assertRaisesRegexp(ValueError, "changing size is not permitted",
-                              root1.set, "SZ", 19)
-        root1.set("SZ", 9)
+                                root1.set, b"SZ", 19)
+        root1.set(b"SZ", 9)
         self.assertRaisesRegexp(ValueError, "changing size is not permitted",
-                              root1.unset, "SZ")
-        g2 = gosgf.Sgf_game.from_string("(;FF[4]GM[1]SZ[19]HA[3])")
+                                root1.unset, b"SZ")
+        g2 = gosgf.Sgf_game.from_string(b"(;FF[4]GM[1]SZ[19]HA[3])")
         root2 = g2.get_root()
-        root2.unset("SZ")
-        root2.set("SZ", 19)
-    
+        root2.unset(b"SZ")
+        root2.set(b"SZ", 19)
+
     def test_set_and_unset_charset(self):
-        g1 = gosgf.Sgf_game.from_string("(;FF[4]CA[utf-8]GM[1]SZ[9]HA[3])")
+        g1 = gosgf.Sgf_game.from_string(b"(;FF[4]CA[utf-8]GM[1]SZ[9]HA[3])")
         self.assertEqual(g1.get_charset(), "UTF-8")
         root1 = g1.get_root()
-        root1.unset("CA")
+        root1.unset(b"CA")
         self.assertEqual(g1.get_charset(), "ISO-8859-1")
-        root1.set("CA", "iso-8859-1")
+        root1.set(b"CA", b"iso-8859-1")
         self.assertEqual(g1.get_charset(), "ISO-8859-1")
-        root1.set("CA", "ascii")
+        root1.set(b"CA", b"ascii")
         self.assertEqual(g1.get_charset(), "ASCII")
-        root1.set("CA", "unknownencoding")
+        root1.set(b"CA", b"unknownencoding")
         self.assertRaisesRegexp(ValueError,
-                              "no codec available for CA unknownencoding",
-                              g1.get_charset)
-    
+                                "no codec available for CA",
+                                g1.get_charset)
+
     def test_node_set_move(self):
-        sgf_game = gosgf.Sgf_game.from_string("(;FF[4]GM[1]SZ[9];B[aa];B[bb])")
+        sgf_game = gosgf.Sgf_game.from_string(b"(;FF[4]GM[1]SZ[9];B[aa];B[bb])")
         root, n1, n2 = sgf_game.get_main_sequence()
         self.assertEqual(root.get_move(), (None, None))
         root.set_move('b', (1, 1))
         n1.set_move('w', (1, 2))
         n2.set_move('b', None)
-        self.assertEqual(root.get('B'), (1, 1))
-        self.assertRaises(KeyError, root.get, 'W')
-        self.assertEqual(n1.get('W'), (1, 2))
-        self.assertRaises(KeyError, n1.get, 'B')
-        self.assertEqual(n2.get('B'), None)
-        self.assertRaises(KeyError, n2.get, 'W')
+        self.assertEqual(root.get(b'B'), (1, 1))
+        self.assertRaises(KeyError, root.get, b'W')
+        self.assertEqual(n1.get(b'W'), (1, 2))
+        self.assertRaises(KeyError, n1.get, b'B')
+        self.assertEqual(n2.get(b'B'), None)
+        self.assertRaises(KeyError, n2.get, b'W')
 
     def test_node_setup_stones(self):
-        sgf_game = gosgf.Sgf_game.from_string("(;FF[4]GM[1]SZ[9]AW[aa:bb])")
+        sgf_game = gosgf.Sgf_game.from_string(b"(;FF[4]GM[1]SZ[9]AW[aa:bb])")
         root = sgf_game.get_root()
         root.set_setup_stones(
             [(1, 2), (3, 4)],
             set(),
             [(1, 3), (4, 5)],
             )
-        self.assertEqual(root.get('AB'), set([(1, 2), (3, 4)]))
-        self.assertRaises(KeyError, root.get, 'AW')
-        self.assertEqual(root.get('AE'), set([(1, 3), (4, 5)]))
+        self.assertEqual(root.get(b'AB'), set([(1, 2), (3, 4)]))
+        self.assertRaises(KeyError, root.get, b'AW')
+        self.assertEqual(root.get(b'AE'), set([(1, 3), (4, 5)]))
 
     def test_add_comment_text(self):
         sgf_game = gosgf.Sgf_game(9)
         root = sgf_game.get_root()
-        root.add_comment_text("hello\nworld")
-        self.assertEqual(root.get('C'), "hello\nworld")
-        root.add_comment_text("hello\naga]in")
-        self.assertEqual(root.get('C'), "hello\nworld\n\nhello\naga]in")
+        root.add_comment_text(b"hello\nworld")
+        self.assertEqual(root.get(b'C'), b"hello\nworld")
+        root.add_comment_text(b"hello\naga]in")
+        self.assertEqual(root.get(b'C'), b"hello\nworld\n\nhello\naga]in")

--- a/tests/gosgf/sgf_test.py
+++ b/tests/gosgf/sgf_test.py
@@ -296,10 +296,10 @@ class SgfTestCase(unittest.TestCase):
         self.assertEqual(g1.get_charset(), "UTF-8")
         root = g1.get_root()
         self.assertEqual(root.get_encoding(), "UTF-8")
-        root.set(b"C", "£".encode('utf-8'))
-        self.assertEqual(root.get(b"C"), "£".encode('utf-8'))
-        self.assertEqual(root.get_raw(b"C"), "£".encode('utf-8'))
-        self.assertEqual(g1.serialise(), dedent("""\
+        root.set(b"C", u"£".encode('utf-8'))
+        self.assertEqual(root.get(b"C"), u"£".encode('utf-8'))
+        self.assertEqual(root.get_raw(b"C"), u"£".encode('utf-8'))
+        self.assertEqual(g1.serialise(), dedent(u"""\
         (;FF[4]C[£]CA[UTF-8]GM[1]SZ[19])
         """).encode('utf-8'))
 
@@ -307,8 +307,8 @@ class SgfTestCase(unittest.TestCase):
         self.assertEqual(g2.get_charset(), "ISO-8859-1")
         root = g2.get_root()
         self.assertEqual(root.get_encoding(), "ISO-8859-1")
-        root.set(b"C", "£".encode('utf-8'))
-        self.assertEqual(root.get(b"C"), "£".encode('utf-8'))
+        root.set(b"C", u"£".encode('utf-8'))
+        self.assertEqual(root.get(b"C"), u"£".encode('utf-8'))
         self.assertEqual(root.get_raw(b"C"), b"\xa3")
         self.assertEqual(g2.serialise(), b"(;FF[4]C[\xa3]CA[ISO-8859-1]GM[1]SZ[19])\n")
 
@@ -316,15 +316,15 @@ class SgfTestCase(unittest.TestCase):
                                 gosgf.Sgf_game, 19, "unknownencoding")
 
     def test_loaded_sgf_game_encoding(self):
-        g1 = gosgf.Sgf_game.from_string("""
+        g1 = gosgf.Sgf_game.from_string(u"""
         (;FF[4]C[£]CA[utf-8]GM[1]SZ[19])
         """.encode('utf-8'))
         self.assertEqual(g1.get_charset(), "UTF-8")
         root = g1.get_root()
         self.assertEqual(root.get_encoding(), "UTF-8")
-        self.assertEqual(root.get(b"C"), "£".encode('utf-8'))
-        self.assertEqual(root.get_raw(b"C"), "£".encode('utf-8'))
-        self.assertEqual(g1.serialise(), dedent("""\
+        self.assertEqual(root.get(b"C"), u"£".encode('utf-8'))
+        self.assertEqual(root.get_raw(b"C"), u"£".encode('utf-8'))
+        self.assertEqual(g1.serialise(), dedent(u"""\
         (;FF[4]C[£]CA[utf-8]GM[1]SZ[19])
         """).encode('utf-8'))
 
@@ -334,9 +334,9 @@ class SgfTestCase(unittest.TestCase):
         self.assertEqual(g2.get_charset(), "ISO-8859-1")
         root = g2.get_root()
         self.assertEqual(root.get_encoding(), "ISO-8859-1")
-        self.assertEqual(root.get(b"C"), "£".encode('utf-8'))
+        self.assertEqual(root.get(b"C"), u"£".encode('utf-8'))
         self.assertEqual(root.get_raw(b"C"), b"\xa3")
-        self.assertEqual(g2.serialise(), dedent("""\
+        self.assertEqual(g2.serialise(), dedent(u"""\
         (;FF[4]C[£]CA[iso-8859-1]GM[1]SZ[19])
         """).encode('iso-8859-1'))
 
@@ -346,9 +346,9 @@ class SgfTestCase(unittest.TestCase):
         self.assertEqual(g3.get_charset(), "ISO-8859-1")
         root = g3.get_root()
         self.assertEqual(root.get_encoding(), "ISO-8859-1")
-        self.assertEqual(root.get(b"C"), "£".encode('utf-8'))
+        self.assertEqual(root.get(b"C"), u"£".encode('utf-8'))
         self.assertEqual(root.get_raw(b"C"), b"\xa3")
-        self.assertEqual(g3.serialise(), dedent("""\
+        self.assertEqual(g3.serialise(), dedent(u"""\
         (;FF[4]C[£]GM[1]SZ[19])
         """).encode('iso-8859-1'))
 
@@ -370,14 +370,14 @@ class SgfTestCase(unittest.TestCase):
             """)
 
     def test_override_encoding(self):
-        g1 = gosgf.Sgf_game.from_string("""
+        g1 = gosgf.Sgf_game.from_string(u"""
         (;FF[4]C[£]CA[iso-8859-1]GM[1]SZ[19])
         """.encode('utf-8'), override_encoding="utf-8")
         root = g1.get_root()
         self.assertEqual(root.get_encoding(), "UTF-8")
-        self.assertEqual(root.get(b"C"), "£".encode('utf-8'))
-        self.assertEqual(root.get_raw(b"C"), "£".encode('utf-8'))
-        self.assertEqual(g1.serialise(), dedent("""\
+        self.assertEqual(root.get(b"C"), u"£".encode('utf-8'))
+        self.assertEqual(root.get_raw(b"C"), u"£".encode('utf-8'))
+        self.assertEqual(g1.serialise(), dedent(u"""\
         (;FF[4]C[£]CA[UTF-8]GM[1]SZ[19])
         """).encode('utf-8'))
 
@@ -386,19 +386,19 @@ class SgfTestCase(unittest.TestCase):
         """, override_encoding="iso-8859-1")
         root = g2.get_root()
         self.assertEqual(root.get_encoding(), "ISO-8859-1")
-        self.assertEqual(root.get(b"C"), "£".encode('utf-8'))
+        self.assertEqual(root.get(b"C"), u"£".encode('utf-8'))
         self.assertEqual(root.get_raw(b"C"), b'\xa3')
         self.assertEqual(g2.serialise().strip(), b"""(;FF[4]C[\xa3]CA[ISO-8859-1]GM[1]SZ[19])""")
 
     def test_serialise_transcoding(self):
-        g1 = gosgf.Sgf_game.from_string("""
+        g1 = gosgf.Sgf_game.from_string(u"""
         (;FF[4]C[£]CA[utf-8]GM[1]SZ[19])
         """.encode('utf-8'))
-        self.assertEqual(g1.serialise(), dedent("""\
+        self.assertEqual(g1.serialise(), dedent(u"""\
         (;FF[4]C[£]CA[utf-8]GM[1]SZ[19])
         """).encode('utf-8'))
         g1.get_root().set(b"CA", b"latin-1")
-        self.assertEqual(g1.serialise(), dedent("""\
+        self.assertEqual(g1.serialise(), dedent(u"""\
         (;FF[4]C[£]CA[latin-1]GM[1]SZ[19])
         """).encode('latin-1'))
         g1.get_root().set(b"CA", b"unknown")
@@ -406,16 +406,16 @@ class SgfTestCase(unittest.TestCase):
                                 g1.serialise)
 
         # improperly-encoded from the start
-        g2 = gosgf.Sgf_game.from_string("""
+        g2 = gosgf.Sgf_game.from_string(u"""
         (;FF[4]C[£]CA[ascii]GM[1]SZ[19])
         """.encode('utf-8'))
-        self.assertEqual(g2.serialise(), dedent("""\
+        self.assertEqual(g2.serialise(), dedent(u"""\
         (;FF[4]C[£]CA[ascii]GM[1]SZ[19])
         """).encode('utf-8'))
         g2.get_root().set(b"CA", b"utf-8")
         self.assertRaises(UnicodeDecodeError, g2.serialise)
 
-        g3 = gosgf.Sgf_game.from_string("""
+        g3 = gosgf.Sgf_game.from_string(u"""
         (;FF[4]C[Δ]CA[utf-8]GM[1]SZ[19])
         """.encode('utf-8'))
         g3.get_root().unset(b"CA")

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -1,5 +1,7 @@
 import unittest
 
+import six
+
 from betago import model
 from betago.dataloader import goboard
 
@@ -14,7 +16,8 @@ class ModelTestCase(unittest.TestCase):
 
         empty_points = model.all_empty_points(board)
 
-        self.assertItemsEqual(
+        six.assertCountEqual(
+            self,
             [(0, 0), (1, 2), (2, 0), (2, 2)],
             empty_points)
 


### PR DESCRIPTION
(see issue #13)

I wanted to re-enable all the CI tests before doing any more big changes, so I thought we should knock this one out.

I pulled just the SGF parsing code out of gomill and updated it for Python 3. Since gomill deals directly with raw string encodings, there were a lot of changes; fortunately it had great test coverage. Then there were some other little changes here and there. I successfully ran training on both Python 2.7 and 3.5.

Since gomill is also MIT-licensed I think we are OK from a licensing point of view, but I don't really know these things. (I also wanted to make sure we gave the original author proper credit)