### PR TITLE
handle *.tar.gz files now found on u-go.net for training

### DIFF
--- a/betago/dataloader/base_processor.py
+++ b/betago/dataloader/base_processor.py
@@ -6,7 +6,7 @@ import os
 import gc
 import glob
 import os.path
-import zipfile
+import tarfile
 import numpy as np
 import argparse
 import multiprocessing
@@ -45,7 +45,7 @@ class DataGenerator(object):
 
     def _generate(self, batch_size, nb_classes):
         for zip_file_name in self.files:
-            file_name = zip_file_name.replace('.zip', '') + 'train'
+            file_name = zip_file_name.replace('.tar.gz', '') + 'train'
             base = self.data_dir + '/' + file_name + '_features_*.npy'
             for feature_file in glob.glob(base):
                 label_file = feature_file.replace('features', 'labels')
@@ -272,7 +272,7 @@ class GoDataProcessor(GoBaseProcessor):
 
     def process_zip(self, dir_name, zip_file_name, data_file_name, game_list):
         # Read zipped file and extract name list
-        this_zip = zipfile.ZipFile(dir_name + '/' + zip_file_name)
+        this_zip = tarfile.TarFile(dir_name + '/' + zip_file_name)
         name_list = this_zip.namelist()
 
         # Determine number of examples
@@ -387,7 +387,7 @@ class GoFileProcessor(GoBaseProcessor):
 
     def process_zip(self, dir_name, zip_file_name, data_file_name, game_list):
         # Read zipped file and extract name list
-        this_zip = zipfile.ZipFile(dir_name + '/' + zip_file_name)
+        this_zip = tarfile.TarFile(dir_name + '/' + zip_file_name)
         name_list = this_zip.namelist()
 
         # Determine number of examples

--- a/betago/dataloader/index_processor.py
+++ b/betago/dataloader/index_processor.py
@@ -94,10 +94,10 @@ class KGSIndex(object):
         Create the actual index representation from the previously downloaded or cached html.
         '''
         index_contents = self.create_index_page()
-        split_page = [item for item in index_contents.split('<a href="') if item.startswith("http://")]
+        split_page = [item for item in index_contents.split('<a href="') if item.startswith("https://")]
         for item in split_page:
             download_url = item.split('">Download')[0]
-            if download_url.endswith('.zip'):
+            if download_url.endswith('.tar.gz'):
                 self.urls.append(download_url)
         for url in self.urls:
             filename = os.path.basename(url)


### PR DESCRIPTION
The format of the HTML index on u-go.net has changed, and *.tar.gz files now need to be processed instead of *.zip.