### PR TITLE
Compatibility with C9.io

### DIFF
--- a/betago/model.py
+++ b/betago/model.py
@@ -57,7 +57,7 @@ class HTTPFrontend(object):
             json_result = jsonify(**result)
             return json_result
 
-        self.app.run(host='0.0.0.0', debug=True, threaded=True, use_reloader=False)
+        self.app.run(host='0.0.0.0', port=int("8081"), debug=True, threaded=True, use_reloader=False)
 
 
 class GoModel(object):

--- a/betago/model.py
+++ b/betago/model.py
@@ -13,7 +13,7 @@ from .processor import ThreePlaneProcessor
 
 class HTTPFrontend(object):
     '''
-    HTTPFrontend is a simple Flask app served on localhost:5000, exposing a REST API to predict
+    HTTPFrontend is a simple Flask app served on localhost:8080, exposing a REST API to predict
     go moves.
     '''
     def __init__(self, bot):
@@ -65,7 +65,7 @@ class HTTPFrontend(object):
             json_result = jsonify(**result)
             return json_result
 
-        self.app.run(host='0.0.0.0', port=int("8081"), debug=True, threaded=True, use_reloader=False)
+        self.app.run(host='0.0.0.0', port=int('8080'), debug=True, threaded=True, use_reloader=False)
 
 
 class GoModel(object):

--- a/betago/model.py
+++ b/betago/model.py
@@ -35,9 +35,17 @@ class HTTPFrontend(object):
         CORS(app, resources={r"/prediction/*": {"origins": "*"}})
         self.app = app
 
+        @app.route('/dist/<path:path>')
+        def static_file_dist(path):
+            return open("ui/dist/" + path).read()
+
+        @app.route('/large/<path:path>')
+        def static_file_large(path):
+            return open("ui/large/" + path).read()
+
         @app.route('/')
         def home():
-            return 'betago'
+            return open("ui/demoBot.html").read()
 
         @app.route('/prediction', methods=['GET', 'POST'])
         def next_move():

--- a/run_demo.sh
+++ b/run_demo.sh
@@ -1,0 +1,5 @@
+cd ..
+virtualenv .betago
+. .betago/bin/activate
+cd betago
+python run_demo.py

--- a/ui/demoBot.html
+++ b/ui/demoBot.html
@@ -84,9 +84,7 @@ jsetup.create('board', function(canvas) {
 
 
     var botcoord;
-    var port = window.location.port;
-    var host = window.location.host;
-    postMove("//" + host + (port=="8081" ? "" : ":8081") + "/prediction", coord,
+    postMove('/prediction', coord,
       function(data) {botcoord = JSON.parse(data);
       });
     coord.i = botcoord.i

--- a/ui/demoBot.html
+++ b/ui/demoBot.html
@@ -84,7 +84,7 @@ jsetup.create('board', function(canvas) {
 
 
     var botcoord;
-    postMove("//" + window.location.host+':5000/prediction', coord,
+    postMove("//" + window.location.host+':8081/prediction', coord,
       function(data) {botcoord = JSON.parse(data)
       });
     coord.i = botcoord.i

--- a/ui/demoBot.html
+++ b/ui/demoBot.html
@@ -84,7 +84,7 @@ jsetup.create('board', function(canvas) {
 
 
     var botcoord;
-    postMove('http://localhost:5000/prediction', coord,
+    postMove("//" + window.location.host+':5000/prediction', coord,
       function(data) {botcoord = JSON.parse(data)
       });
     coord.i = botcoord.i

--- a/ui/demoBot.html
+++ b/ui/demoBot.html
@@ -84,8 +84,10 @@ jsetup.create('board', function(canvas) {
 
 
     var botcoord;
-    postMove("//" + window.location.host+':8081/prediction', coord,
-      function(data) {botcoord = JSON.parse(data)
+    var port = window.location.port;
+    var host = window.location.host;
+    postMove("//" + host + (port=="8081" ? "" : ":8081") + "/prediction", coord,
+      function(data) {botcoord = JSON.parse(data);
       });
     coord.i = botcoord.i
     coord.j = botcoord.j


### PR DESCRIPTION
### BetaGo now works flawlessly with web IDE's such as C9.io.

Changes:
---
- Change port number from `5000` to `8081`
- User interface no longer requires `localhost` (can use any web address)
- User interface is automatically hosted at `[server root]:8081`
- Bash script to easily run the demo (once installed)